### PR TITLE
Use raw strings in config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ WEBPACK_LOADER = {
         'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats.json'),
         'POLL_INTERVAL': 0.1,
         'TIMEOUT': None,
-        'IGNORE': ['.+\.hot-update.js', '.+\.map']
+        'IGNORE': [r'.+\.hot-update.js', r'.+\.map']
     }
 }
 ```


### PR DESCRIPTION
As of python 3.6 unrecognised escape sequences (in this case, the '\.' ) raise a DeprecationWarning.

This is fixed by replacing them with raw strings.