### PR TITLE
Added support for module name and auto-resolution of chunk name

### DIFF
--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -14,6 +14,12 @@ def render_bundle(bundle_name, extension=None, config='DEFAULT', attrs=''):
 
 
 @register.simple_tag
+def render_bundle_auto(bundle_name, extension=None, config='DEFAULT', attrs=''):
+    tags = utils.get_as_tags(bundle_name, extension=extension, config=config, attrs=attrs, mode='auto')
+    return mark_safe('\n'.join(tags))
+
+
+@register.simple_tag
 def webpack_static(asset_name, config='DEFAULT'):
     return utils.get_static(asset_name, config=config)
 

--- a/webpack_loader/utils.py
+++ b/webpack_loader/utils.py
@@ -19,19 +19,19 @@ def _filter_by_extension(bundle, extension):
             yield chunk
 
 
-def _get_bundle(bundle_name, extension, config):
-    bundle = get_loader(config).get_bundle(bundle_name)
+def _get_bundle(bundle_name, extension, config, mode):
+    bundle = get_loader(config).get_bundle(bundle_name, mode)
     if extension:
         bundle = _filter_by_extension(bundle, extension)
     return bundle
 
 
-def get_files(bundle_name, extension=None, config='DEFAULT'):
+def get_files(bundle_name, extension=None, config='DEFAULT', mode="explicit"):
     '''Returns list of chunks from named bundle'''
     return list(_get_bundle(bundle_name, extension, config))
 
 
-def get_as_tags(bundle_name, extension=None, config='DEFAULT', attrs=''):
+def get_as_tags(bundle_name, extension=None, config='DEFAULT', attrs='', mode='explicit'):
     '''
     Get a list of formatted <script> & <link> tags for the assets in the
     named bundle.
@@ -42,7 +42,7 @@ def get_as_tags(bundle_name, extension=None, config='DEFAULT', attrs=''):
     :return: a list of formatted tags as strings
     '''
 
-    bundle = _get_bundle(bundle_name, extension, config)
+    bundle = _get_bundle(bundle_name, extension, config, mode)
     tags = []
     for chunk in bundle:
         if chunk['name'].endswith(('.js', '.js.gz')):


### PR DESCRIPTION
I have multiple webpack entry points in my project, and depending on changes to JS or CSS code I made in any given module, I'd have to constantly change the bundle_name value.  See issue #165.  So, to prevent having to constantly make these changes, and to avoid breaking current functionality, I created a new template tag, `render_bundle_auto`, where you can simply use the entry point name as your `bundle_name` and the plugin will search for that name within the chunk names.  If the module name is in a chunk name, it will include the tag.  I have tested this for my own config and it's working fine, but there are very different webpack configs out there, so that's a major caveat.

Also, this code assumes that if you include a content hash in your Webpack config, that it is separated by a hyphen (seems like this is the convention?)

I'm very open to suggestions or changes.