### PR TITLE
Update examples to use webpack-bundle-tracker@1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,7 @@ examples/**/ve/
 examples/**/venv/
 examples/**/node_modules/
 examples/**/assets/bundles/
-examples/**/assets/webpack-stats.json
+examples/**/webpack-stats.json
 
 tests/ve/
 tests/ve3/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ pip install django-webpack-loader
 
 <br>
 
+## Migrating from version < 1.0.0
+
+In order to use `django-webpack-loader>=1.0.0`, you must ensure that `webpack-bundle-tracker@1.0.0` is being used on the JavaScript side. It's recommended that you always keep at least minor version parity across both packages, for full compatibility.
+
+This is necessary because the formatting of `webpack-stats.json` that `webpack-bundle-tracker` outputs has changed starting at version `1.0.0-alpha.1`. Starting at `django-webpack-loader==1.0.0`, this is the only formatting accepted here, meaning that other versions of that package don't output compatible files anymore, thereby breaking compatibility with older `webpack-bundle-tracker` releases.
+
+<br>
+
 ## Configuration
 
 <br>

--- a/examples/code-splitting/app/settings.py
+++ b/examples/code-splitting/app/settings.py
@@ -109,7 +109,7 @@ STATICFILES_DIRS = (
 WEBPACK_LOADER = {
     'DEFAULT': {
         'BUNDLE_DIR_NAME': 'bundles/',
-        'STATS_FILE': os.path.join(BASE_DIR, 'assets/bundles/webpack-stats.json')
+        'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats.json')
     }
 }
 

--- a/examples/code-splitting/package.json
+++ b/examples/code-splitting/package.json
@@ -13,7 +13,7 @@
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
     "webpack": "^4.0.0",
-    "webpack-bundle-tracker": "1.0.0-alpha.1",
+    "webpack-bundle-tracker": "1.0.0",
     "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.0.0"
   }

--- a/examples/hot-reload/app/settings.py
+++ b/examples/hot-reload/app/settings.py
@@ -109,7 +109,7 @@ STATICFILES_DIRS = (
 WEBPACK_LOADER = {
     'DEFAULT': {
         'BUNDLE_DIR_NAME': 'bundles/',
-        'STATS_FILE': os.path.join(BASE_DIR, 'assets/bundles/webpack-stats.json')
+        'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats.json')
     }
 }
 

--- a/examples/hot-reload/package.json
+++ b/examples/hot-reload/package.json
@@ -15,7 +15,7 @@
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
     "webpack": "^4.0.0",
-    "webpack-bundle-tracker": "1.0.0-alpha.1",
+    "webpack-bundle-tracker": "1.0.0",
     "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.0.0"
   }

--- a/examples/simple/app/settings.py
+++ b/examples/simple/app/settings.py
@@ -109,7 +109,7 @@ STATICFILES_DIRS = (
 WEBPACK_LOADER = {
     'DEFAULT': {
         'BUNDLE_DIR_NAME': 'bundles/',
-        'STATS_FILE': os.path.join(BASE_DIR, 'assets/bundles/webpack-stats.json')
+        'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats.json')
     }
 }
 

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -15,7 +15,7 @@
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
     "webpack": "^4.0.0",
-    "webpack-bundle-tracker": "1.0.0-alpha.1",
+    "webpack-bundle-tracker": "1.0.0",
     "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.0.0"
   }


### PR DESCRIPTION
Closes #224
Closes #272 