### PR TITLE
Fix RemovedInDjango41Warning

### DIFF
--- a/webpack_loader/__init__.py
+++ b/webpack_loader/__init__.py
@@ -1,5 +1,7 @@
 __author__ = 'Owais Lone'
 __version__ = '1.1.0'
 
+import django
+
 if django.VERSION < (3, 2):  # pragma: no cover
     default_app_config = 'webpack_loader.apps.WebpackLoaderConfig'

--- a/webpack_loader/__init__.py
+++ b/webpack_loader/__init__.py
@@ -1,4 +1,5 @@
 __author__ = 'Owais Lone'
 __version__ = '1.1.0'
 
-default_app_config = 'webpack_loader.apps.WebpackLoaderConfig'
+if django.VERSION < (3, 2):  # pragma: no cover
+    default_app_config = 'webpack_loader.apps.WebpackLoaderConfig'


### PR DESCRIPTION
RemovedInDjango41Warning: 'webpack_loader' defines default_app_config = 'webpack_loader.apps.WebpackLoaderConfig'. Django now detects this configuration automatically. You can remove default_app_config.