### PR TITLE
Added skip_common_chunks argument to render_bundle to address duplicate script tags

### DIFF
--- a/tests/webpack.config.skipCommon.js
+++ b/tests/webpack.config.skipCommon.js
@@ -1,0 +1,58 @@
+var path = require("path");
+var webpack = require('webpack');
+var BundleTracker = require('webpack-bundle-tracker');
+var MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
+
+module.exports = {
+  context: __dirname,
+  entry: {
+      app1: './assets/js/index',
+      app2: './assets/js/index'
+  },
+  output: {
+      path: path.resolve('./assets/django_webpack_loader_bundles/'),
+      filename: "[name].js",
+      chunkFilename: "[name].js"
+  },
+
+  plugins: [
+    new MiniCssExtractPlugin(),
+    new BundleTracker({path: __dirname, filename: './webpack-stats.json'}),
+  ],
+
+  module: {
+    rules: [
+      // we pass the output from babel loader to react-hot loader
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-react']
+          }
+        }
+      },
+      { test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }
+    ],
+  },
+
+  resolve: {
+    modules: ['node_modules'],
+    extensions: ['.js', '.jsx']
+  },
+
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        commons: {
+          test: /[\\/]node_modules[\\/]/,
+          name: 'vendors',
+          chunks: 'all',
+          enforce: true
+        }
+      }
+    }
+  }
+}

--- a/webpack_loader/contrib/jinja2ext.py
+++ b/webpack_loader/contrib/jinja2ext.py
@@ -1,4 +1,5 @@
 import jinja2.ext
+from jinja2.utils import contextfunction
 
 from ..templatetags.webpack_loader import render_bundle
 
@@ -6,5 +7,4 @@ from ..templatetags.webpack_loader import render_bundle
 class WebpackExtension(jinja2.ext.Extension):
     def __init__(self, environment):
         super(WebpackExtension, self).__init__(environment)
-        environment.globals["context"] = dict()
-        environment.globals["render_bundle"] = lambda *a, **k: jinja2.Markup(render_bundle(environment.globals["context"], *a, **k))
+        environment.globals["render_bundle"] = contextfunction(lambda *a, **k: jinja2.Markup(render_bundle(*a, **k)))

--- a/webpack_loader/contrib/jinja2ext.py
+++ b/webpack_loader/contrib/jinja2ext.py
@@ -6,4 +6,5 @@ from ..templatetags.webpack_loader import render_bundle
 class WebpackExtension(jinja2.ext.Extension):
     def __init__(self, environment):
         super(WebpackExtension, self).__init__(environment)
-        environment.globals["render_bundle"] = lambda *a, **k: jinja2.Markup(render_bundle(*a, **k))
+        environment.globals["context"] = dict()
+        environment.globals["render_bundle"] = lambda *a, **k: jinja2.Markup(render_bundle(environment.globals["context"], *a, **k))

--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -14,12 +14,15 @@ def render_bundle(context, bundle_name, extension=None, config='DEFAULT', suffix
         suffix=suffix, attrs=attrs, is_preload=is_preload
     )
     if "webpack_loader_used_tags" not in context:
+        # Jinja Context object stores actual mutable variables on vars attribute that doesn't exist on normal Django Context
+        if hasattr(context, "vars"):
+            context = context.vars
         context["webpack_loader_used_tags"] = set()
     used_tags = context["webpack_loader_used_tags"]
     if skip_common_chunks:
         tags = [tag for tag in tags if tag not in used_tags]
     context["webpack_loader_used_tags"].update(tags)
-
+    
     return mark_safe('\n'.join(tags))
 
 @register.simple_tag

--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -13,14 +13,13 @@ def render_bundle(context, bundle_name, extension=None, config='DEFAULT', suffix
         bundle_name, extension=extension, config=config,
         suffix=suffix, attrs=attrs, is_preload=is_preload
     )
-    used_tags = context.get("webpack_loader_used_tags", [])
-    if not used_tags:
-        context["webpack_loader_used_tags"] = []
+    if "webpack_loader_used_tags" not in context:
+        context["webpack_loader_used_tags"] = set()
+    used_tags = context["webpack_loader_used_tags"]
     if skip_common_chunks:
         tags = [mark_safe(tag) for tag in tags if tag not in used_tags]
+    context["webpack_loader_used_tags"].update(tags)
 
-    context["webpack_loader_used_tags"] = context["webpack_loader_used_tags"] + tags
-    
     return mark_safe('\n'.join(tags))
 
 @register.simple_tag

--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -17,7 +17,7 @@ def render_bundle(context, bundle_name, extension=None, config='DEFAULT', suffix
         context["webpack_loader_used_tags"] = set()
     used_tags = context["webpack_loader_used_tags"]
     if skip_common_chunks:
-        tags = [mark_safe(tag) for tag in tags if tag not in used_tags]
+        tags = [tag for tag in tags if tag not in used_tags]
     context["webpack_loader_used_tags"].update(tags)
 
     return mark_safe('\n'.join(tags))


### PR DESCRIPTION
Added skip_common_chunks to render_bundle to address duplicate script tag issue #289. Uses context to store a list of all loaded tags by default and skips them if the option is set for that invocation of render_bundle.

I'm not sure if this should be included, but for me the use case is when I am composing a page out of templates that might include different entry points but with shared chunks. Ideally you just have one entry point but sometimes it might require refactoring that wouldn't be immediately necessary except for this issue. 

Open questions I have:
1. What should the default value of skip_common_chunks be? False preserves existing behavior, but I'm not sure that's desirable.
2. Is it acceptable to add the overhead of checking and setting the context even for the single bundle use case? You need to track the loaded tags on every invocation of render_bundle, otherwise later calls with skip_common_chunks will not behave correctly. There could also be a config option set that globally enables/disables checking the context so that the overhead could be avoided. 
3. Should the context variable name be set via a config option or otherwise be customizable?