### PR TITLE
Add skip_common_chunks functionality

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,33 +3,21 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-3.5-20
-      - test-3.5-21
-      - test-3.5-22
-
-      - test-3.6-20
-      - test-3.6-21
       - test-3.6-22
       - test-3.6-30
       - test-3.6-31
       - test-3.6-32
 
-      - test-3.7-20
-      - test-3.7-21
       - test-3.7-22
       - test-3.7-30
       - test-3.7-31
       - test-3.7-32
 
-      - test-3.8-20
-      - test-3.8-21
       - test-3.8-22
       - test-3.8-30
       - test-3.8-31
       - test-3.8-32
 
-      - test-3.9-20
-      - test-3.9-21
       - test-3.9-22
       - test-3.9-30
       - test-3.9-31
@@ -37,33 +25,21 @@ workflows:
 
       - done:
           requires:
-            - test-3.5-20
-            - test-3.5-21
-            - test-3.5-22
-
-            - test-3.6-20
-            - test-3.6-21
             - test-3.6-22
             - test-3.6-30
             - test-3.6-31
             - test-3.6-32
 
-            - test-3.7-20
-            - test-3.7-21
             - test-3.7-22
             - test-3.7-30
             - test-3.7-31
             - test-3.7-32
 
-            - test-3.8-20
-            - test-3.8-21
             - test-3.8-22
             - test-3.8-30
             - test-3.8-31
             - test-3.8-32
 
-            - test-3.9-20
-            - test-3.9-21
             - test-3.9-22
             - test-3.9-30
             - test-3.9-31
@@ -118,37 +94,6 @@ jobs:
           environment:
             COVERALLS_PARALLEL: 1
 
-  test-3.5-20:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.5-stretch-node
-    environment:
-      DJANGO_VERSION: "20"
-  test-3.5-21:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.5-stretch-node
-    environment:
-      DJANGO_VERSION: "21"
-  test-3.5-22:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.5-stretch-node
-    environment:
-      DJANGO_VERSION: "22"
-
-  test-3.6-20:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.6-stretch-node
-    environment:
-      DJANGO_VERSION: "20"
-  test-3.6-21:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.6-stretch-node
-    environment:
-      DJANGO_VERSION: "21"
   test-3.6-22:
     <<: *test-template
     docker:
@@ -174,18 +119,6 @@ jobs:
     environment:
       DJANGO_VERSION: "32"
 
-  test-3.7-20:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.7-stretch-node
-    environment:
-      DJANGO_VERSION: "20"
-  test-3.7-21:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.7-stretch-node
-    environment:
-      DJANGO_VERSION: "21"
   test-3.7-22:
     <<: *test-template
     docker:
@@ -211,18 +144,6 @@ jobs:
     environment:
       DJANGO_VERSION: "32"
 
-  test-3.8-20:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.8-buster-node
-    environment:
-      DJANGO_VERSION: "20"
-  test-3.8-21:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.8-buster-node
-    environment:
-      DJANGO_VERSION: "21"
   test-3.8-22:
     <<: *test-template
     docker:
@@ -248,18 +169,6 @@ jobs:
     environment:
       DJANGO_VERSION: "32"
 
-  test-3.9-20:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.9-buster-node
-    environment:
-      DJANGO_VERSION: "20"
-  test-3.9-21:
-    <<: *test-template
-    docker:
-      - image: circleci/python:3.9-buster-node
-    environment:
-      DJANGO_VERSION: "21"
   test-3.9-22:
     <<: *test-template
     docker:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 twine==3.4.1
-Django==3.2.4
+Django==3.2.7
 django-jinja==2.7.0
 unittest2==1.1.0
 wheel==0.36.2

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,11 @@ def rel(*parts):
     '''returns the relative path to a file wrt to the current directory'''
     return os.path.abspath(os.path.join(os.path.dirname(__file__), *parts))
 
-README = open('README.md', 'r').read()
+with open('README.md', 'r') as handler:
+  README = handler.read()
 
 with open(rel('webpack_loader', '__init__.py')) as handler:
-    INIT_PY = handler.read()
+  INIT_PY = handler.read()
 
 
 VERSION = re.findall("__version__ = '([^']+)'", INIT_PY)[0]
@@ -30,7 +31,6 @@ setup(
   keywords = ['django', 'webpack', 'assets'], # arbitrary keywords
   classifiers = [
     'Programming Language :: Python',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',

--- a/tests/app/templates/home-deduplicated.jinja
+++ b/tests/app/templates/home-deduplicated.jinja
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Example</title>
+    {{ render_bundle('app1', 'js') }}
+    {{ render_bundle('app2', 'js', skip_common_chunks=True) }}
+  </head>
+
+  <body>
+    <div id="react-app"></div>
+    {{ render_bundle('app1', 'js', skip_common_chunks=True) }}
+    {{ render_bundle('app2', 'js', skip_common_chunks=True) }}
+  </body>
+</html>

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -334,8 +334,9 @@ class LoaderTestCase(TestCase):
             self.assertTrue(elapsed < wait_for)
 
     def test_skip_common_chunks_djangoengine(self):
-        'Test case for deduplication of modules with the django engine.'
+        """Test case for deduplication of modules with the django engine."""
         self.compile_bundles('webpack.config.skipCommon.js')
+
         django_engine = engines['django']
         dups_template = django_engine.from_string(template_code=(
             r'{% load render_bundle from webpack_loader %}'
@@ -354,11 +355,13 @@ class LoaderTestCase(TestCase):
         rendered_template = dups_template.render(
             context=None, request=request)
         used_tags = getattr(request, '_webpack_loader_used_tags', None)
+
         self.assertIsNotNone(used_tags, msg=(
             '_webpack_loader_used_tags should be a property of request!'))
         self.assertEqual(rendered_template.count(asset_app1), 1)
         self.assertEqual(rendered_template.count(asset_app2), 1)
         self.assertEqual(rendered_template.count(asset_vendor), 2)
+
         nodups_template = django_engine.from_string(template_code=(
             r'{% load render_bundle from webpack_loader %}'
             r'{% render_bundle "app1" %}'
@@ -368,6 +371,7 @@ class LoaderTestCase(TestCase):
         rendered_template = nodups_template.render(
             context=None, request=request)
         used_tags = getattr(request, '_webpack_loader_used_tags', None)
+
         self.assertIsNotNone(used_tags, msg=(
             '_webpack_loader_used_tags should be a property of request!'))
         self.assertEqual(rendered_template.count(asset_app1), 1)
@@ -375,8 +379,9 @@ class LoaderTestCase(TestCase):
         self.assertEqual(rendered_template.count(asset_vendor), 1)
 
     def test_skip_common_chunks_jinja2engine(self):
-        'Test case for deduplication of modules with the Jinja2 engine.'
+        """Test case for deduplication of modules with the Jinja2 engine."""
         self.compile_bundles('webpack.config.skipCommon.js')
+
         view = TemplateView.as_view(template_name='home-deduplicated.jinja')
         settings = {
             'TEMPLATES': [
@@ -399,6 +404,7 @@ class LoaderTestCase(TestCase):
         asset_app2 = (
             '<script src="/static/django_webpack_loader_bundles/app2.js" >'
             '</script>')
+
         with self.settings(**settings):
             request = self.factory.get('/')
             result = view(request)  # type: TemplateResponse

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -5,24 +5,24 @@ from shutil import rmtree
 from subprocess import call
 from threading import Thread
 
-import django
 from django.conf import settings
-from django.test import RequestFactory, TestCase
+from django.template import engines
+from django.template.backends.django import Template
+from django.template.response import TemplateResponse
+from django.test.client import RequestFactory
+from django.test.testcases import TestCase
 from django.views.generic.base import TemplateView
-from django.template import Context, Template
 from django_jinja.builtins import DEFAULT_EXTENSIONS
-from unittest2 import skipIf
-from webpack_loader.exceptions import (
-    WebpackError,
-    WebpackLoaderBadStatsError,
-    WebpackLoaderTimeoutError,
-    WebpackBundleLookupError
-)
+
+from webpack_loader.exceptions import (WebpackBundleLookupError, WebpackError,
+                                       WebpackLoaderBadStatsError,
+                                       WebpackLoaderTimeoutError)
 from webpack_loader.utils import get_loader
 
-
-BUNDLE_PATH = os.path.join(settings.BASE_DIR, 'assets/django_webpack_loader_bundles/')
+BUNDLE_PATH = os.path.join(
+    settings.BASE_DIR, 'assets/django_webpack_loader_bundles/')
 DEFAULT_CONFIG = 'DEFAULT'
+_OUR_EXTENSION = 'webpack_loader.contrib.jinja2ext.WebpackExtension'
 
 
 class LoaderTestCase(TestCase):
@@ -38,23 +38,21 @@ class LoaderTestCase(TestCase):
             time.sleep(wait)
         call(['./node_modules/.bin/webpack', '--config', config])
 
-    @skipIf(django.VERSION < (1, 7),
-            'not supported in this django version')
     def test_config_check(self):
         from webpack_loader.apps import webpack_cfg_check
         from webpack_loader.errors import BAD_CONFIG_ERROR
 
         with self.settings(WEBPACK_LOADER={
-                                'BUNDLE_DIR_NAME': 'django_webpack_loader_bundles/',
-                                'STATS_FILE': 'webpack-stats.json',
-                           }):
+            'BUNDLE_DIR_NAME': 'django_webpack_loader_bundles/',
+            'STATS_FILE': 'webpack-stats.json',
+        }):
             errors = webpack_cfg_check(None)
             expected_errors = [BAD_CONFIG_ERROR]
             self.assertEqual(errors, expected_errors)
 
         with self.settings(WEBPACK_LOADER={
-                                'DEFAULT': {}
-                           }):
+            'DEFAULT': {}
+        }):
             errors = webpack_cfg_check(None)
             expected_errors = []
             self.assertEqual(errors, expected_errors)
@@ -70,18 +68,28 @@ class LoaderTestCase(TestCase):
         self.assertEqual(len(chunks), 1)
 
         files = assets['assets']
-        self.assertEqual(files['main.css']['path'], os.path.join(settings.BASE_DIR, 'assets/django_webpack_loader_bundles/main.css'))
-        self.assertEqual(files['main.js']['path'], os.path.join(settings.BASE_DIR, 'assets/django_webpack_loader_bundles/main.js'))
+        self.assertEqual(
+            files['main.css']['path'],
+            os.path.join(
+                settings.BASE_DIR,
+                'assets/django_webpack_loader_bundles/main.css'))
+        self.assertEqual(
+            files['main.js']['path'],
+            os.path.join(
+                settings.BASE_DIR,
+                'assets/django_webpack_loader_bundles/main.js'))
 
     def test_default_ignore_config_ignores_map_files(self):
         self.compile_bundles('webpack.config.sourcemaps.js')
         chunks = get_loader('NO_IGNORE_APP').get_bundle('main')
-        has_map_files_chunks = any([".map" in chunk["name"] for chunk in chunks])
+        has_map_files_chunks = \
+            any(['.map' in chunk['name'] for chunk in chunks])
 
         self.assertTrue(has_map_files_chunks)
 
         chunks = get_loader(DEFAULT_CONFIG).get_bundle('main')
-        has_map_files_chunks = any([".map" in chunk["name"] for chunk in chunks])
+        has_map_files_chunks = \
+            any(['.map' in chunk['name'] for chunk in chunks])
 
         self.assertFalse(has_map_files_chunks)
 
@@ -96,14 +104,23 @@ class LoaderTestCase(TestCase):
         self.assertEqual(len(chunks), 1)
 
         files = assets['assets']
-        self.assertEqual(files['main.css']['path'], os.path.join(settings.BASE_DIR, 'assets/django_webpack_loader_bundles/main.css'))
-        self.assertEqual(files['main.js.gz']['path'], os.path.join(settings.BASE_DIR, 'assets/django_webpack_loader_bundles/main.js.gz'))
+        self.assertEqual(
+            files['main.css']['path'],
+            os.path.join(
+                settings.BASE_DIR,
+                'assets/django_webpack_loader_bundles/main.css'))
+        self.assertEqual(
+            files['main.js.gz']['path'],
+            os.path.join(
+                settings.BASE_DIR,
+                'assets/django_webpack_loader_bundles/main.js.gz'))
 
     def test_static_url(self):
         self.compile_bundles('webpack.config.publicPath.js')
         assets = get_loader(DEFAULT_CONFIG).get_assets()
         self.assertEqual(assets['status'], 'done')
-        self.assertEqual(assets['publicPath'], 'http://custom-static-host.com/')
+        self.assertEqual(assets['publicPath'],
+                         'http://custom-static-host.com/')
 
     def test_code_spliting(self):
         self.compile_bundles('webpack.config.split.js')
@@ -116,8 +133,11 @@ class LoaderTestCase(TestCase):
         self.assertEquals(len(chunks), 1)
 
         files = assets['assets']
-        self.assertEqual(files['main.js']['path'], os.path.join(settings.BASE_DIR, 'assets/django_webpack_loader_bundles/main.js'))
-        self.assertEqual(files['vendors.js']['path'], os.path.join(settings.BASE_DIR, 'assets/django_webpack_loader_bundles/vendors.js'))
+        self.assertEqual(files['main.js']['path'], os.path.join(
+            settings.BASE_DIR, 'assets/django_webpack_loader_bundles/main.js'))
+        self.assertEqual(files['vendors.js']['path'], os.path.join(
+            settings.BASE_DIR,
+            'assets/django_webpack_loader_bundles/vendors.js'))
 
     def test_templatetags(self):
         self.compile_bundles('webpack.config.simple.js')
@@ -125,23 +145,40 @@ class LoaderTestCase(TestCase):
         view = TemplateView.as_view(template_name='home.html')
         request = self.factory.get('/')
         result = view(request)
-        self.assertIn('<link href="/static/django_webpack_loader_bundles/main.css" rel="stylesheet" />', result.rendered_content)
-        self.assertIn('<script src="/static/django_webpack_loader_bundles/main.js" async charset="UTF-8"></script>', result.rendered_content)
+        self.assertIn((
+            '<link href="/static/django_webpack_loader_bundles/main.css" '
+            'rel="stylesheet" />'),
+            result.rendered_content)
+        self.assertIn((
+            '<script src="/static/django_webpack_loader_bundles/main.js" '
+            'async charset="UTF-8"></script>'), result.rendered_content)
 
-        self.assertIn('<link href="/static/django_webpack_loader_bundles/app2.css" rel="stylesheet" />', result.rendered_content)
-        self.assertIn('<script src="/static/django_webpack_loader_bundles/app2.js" ></script>', result.rendered_content)
-        self.assertIn('<img src="/static/my-image.png"/>', result.rendered_content)
+        self.assertIn((
+            '<link href="/static/django_webpack_loader_bundles/app2.css" '
+            'rel="stylesheet" />'), result.rendered_content)
+        self.assertIn((
+            '<script src="/static/django_webpack_loader_bundles/app2.js" >'
+            '</script>'), result.rendered_content)
+        self.assertIn(
+            '<img src="/static/my-image.png"/>', result.rendered_content)
 
         view = TemplateView.as_view(template_name='only_files.html')
         result = view(request)
-        self.assertIn("var contentCss = '/static/django_webpack_loader_bundles/main.css'", result.rendered_content)
-        self.assertIn("var contentJS = '/static/django_webpack_loader_bundles/main.js'", result.rendered_content)
+        self.assertIn((
+            "var contentCss = "
+            "'/static/django_webpack_loader_bundles/main.css'"),
+            result.rendered_content)
+        self.assertIn(
+            "var contentJS = '/static/django_webpack_loader_bundles/main.js'",
+            result.rendered_content)
 
         self.compile_bundles('webpack.config.publicPath.js')
         view = TemplateView.as_view(template_name='home.html')
         request = self.factory.get('/')
         result = view(request)
-        self.assertIn('<img src="http://custom-static-host.com/my-image.png"/>', result.rendered_content)
+        self.assertIn(
+            '<img src="http://custom-static-host.com/my-image.png"/>',
+            result.rendered_content)
 
     def test_preload(self):
         self.compile_bundles('webpack.config.simple.js')
@@ -150,12 +187,21 @@ class LoaderTestCase(TestCase):
         result = view(request)
 
         # Preload
-        self.assertIn('<link href="/static/django_webpack_loader_bundles/main.css" rel="preload" as="style" />', result.rendered_content)
-        self.assertIn('<link rel="preload" as="script" href="/static/django_webpack_loader_bundles/main.js" />', result.rendered_content)
+        self.assertIn((
+            '<link href="/static/django_webpack_loader_bundles/main.css" '
+            'rel="preload" as="style" />'), result.rendered_content)
+        self.assertIn((
+            '<link rel="preload" as="script" href="/static/'
+            'django_webpack_loader_bundles/main.js" />'),
+            result.rendered_content)
 
         # Resources
-        self.assertIn('<link href="/static/django_webpack_loader_bundles/main.css" rel="stylesheet" />', result.rendered_content)
-        self.assertIn('<script src="/static/django_webpack_loader_bundles/main.js" ></script>', result.rendered_content)
+        self.assertIn((
+            '<link href="/static/django_webpack_loader_bundles/main.css" '
+            'rel="stylesheet" />'), result.rendered_content)
+        self.assertIn((
+            '<script src="/static/django_webpack_loader_bundles/main.js" >'
+            '</script>'), result.rendered_content)
 
     def test_append_extensions(self):
         self.compile_bundles('webpack.config.gzipTest.js')
@@ -163,47 +209,44 @@ class LoaderTestCase(TestCase):
         request = self.factory.get('/')
         result = view(request)
 
-        self.assertIn('<script src="/static/django_webpack_loader_bundles/main.js.gz" ></script>', result.rendered_content)
+        self.assertIn((
+            '<script src="/static/django_webpack_loader_bundles/main.js.gz" >'
+            '</script>'), result.rendered_content)
 
     def test_jinja2(self):
         self.compile_bundles('webpack.config.simple.js')
         self.compile_bundles('webpack.config.app2.js')
         view = TemplateView.as_view(template_name='home.jinja')
 
-        if django.VERSION >= (1, 8):
-            settings = {
-                'TEMPLATES': [
-                    {
-                        "BACKEND": "django_jinja.backend.Jinja2",
-                        "APP_DIRS": True,
-                        "OPTIONS": {
-                            "match_extension": ".jinja",
-                            "extensions": DEFAULT_EXTENSIONS + [
-                                "webpack_loader.contrib.jinja2ext.WebpackExtension",
-                            ]
-                        }
-                    },
-                ]
-            }
-        else:
-            settings = {
-                'TEMPLATE_LOADERS': (
-                    'django_jinja.loaders.FileSystemLoader',
-                    'django_jinja.loaders.AppLoader',
-                ),
-            }
+        settings = {
+            'TEMPLATES': [
+                {
+                    'BACKEND': 'django_jinja.backend.Jinja2',
+                    'APP_DIRS': True,
+                    'OPTIONS': {
+                        'match_extension': '.jinja',
+                        'extensions': DEFAULT_EXTENSIONS + [_OUR_EXTENSION],
+                    }
+                },
+            ]
+        }
         with self.settings(**settings):
             request = self.factory.get('/')
             result = view(request)
-            self.assertIn('<link href="/static/django_webpack_loader_bundles/main.css" rel="stylesheet" />', result.rendered_content)
-            self.assertIn('<script src="/static/django_webpack_loader_bundles/main.js" async charset="UTF-8"></script>', result.rendered_content)
+            self.assertIn((
+                '<link href="/static/django_webpack_loader_bundles'
+                '/main.css" rel="stylesheet" />'), result.rendered_content)
+            self.assertIn((
+                '<script src="/static/django_webpack_loader_bundles/main.js" '
+                'async charset="UTF-8"></script>'), result.rendered_content)
 
     def test_reporting_errors(self):
         self.compile_bundles('webpack.config.error.js')
         try:
             get_loader(DEFAULT_CONFIG).get_bundle('main')
         except WebpackError as e:
-            self.assertIn("Can't resolve 'the-library-that-did-not-exist'", str(e))
+            self.assertIn(
+                "Can't resolve 'the-library-that-did-not-exist'", str(e))
 
     def test_missing_bundle(self):
         missing_bundle_name = 'missing_bundle'
@@ -211,7 +254,9 @@ class LoaderTestCase(TestCase):
         try:
             get_loader(DEFAULT_CONFIG).get_bundle(missing_bundle_name)
         except WebpackBundleLookupError as e:
-            self.assertIn('Cannot resolve bundle {0}'.format(missing_bundle_name), str(e))
+            self.assertIn(
+                'Cannot resolve bundle {0}'.format(missing_bundle_name),
+                str(e))
 
     def test_missing_stats_file(self):
         stats_file = settings.WEBPACK_LOADER[DEFAULT_CONFIG]['STATS_FILE']
@@ -228,20 +273,18 @@ class LoaderTestCase(TestCase):
 
     def test_timeouts(self):
         with self.settings(DEBUG=True):
-            with open(
-                settings.WEBPACK_LOADER[DEFAULT_CONFIG]['STATS_FILE'], 'w'
-            ) as stats_file:
-                stats_file.write(json.dumps({'status': 'compile'}))
+            statsfile = settings.WEBPACK_LOADER[DEFAULT_CONFIG]['STATS_FILE']
+            with open(statsfile, 'w') as fd:
+                fd.write(json.dumps({'status': 'compile'}))
             loader = get_loader(DEFAULT_CONFIG)
             loader.config['TIMEOUT'] = 0.1
             with self.assertRaises(WebpackLoaderTimeoutError):
                 loader.get_bundle('main')
 
     def test_bad_status_in_production(self):
-        with open(
-            settings.WEBPACK_LOADER[DEFAULT_CONFIG]['STATS_FILE'], 'w'
-        ) as stats_file:
-            stats_file.write(json.dumps({'status': 'unexpected-status'}))
+        statsfile = settings.WEBPACK_LOADER[DEFAULT_CONFIG]['STATS_FILE']
+        with open(statsfile, 'w') as fd:
+            fd.write(json.dumps({'status': 'unexpected-status'}))
 
         try:
             get_loader(DEFAULT_CONFIG).get_bundle('main')
@@ -260,12 +303,18 @@ class LoaderTestCase(TestCase):
         view = TemplateView.as_view(template_name='home.html')
 
         with self.settings(DEBUG=True):
-            open(settings.WEBPACK_LOADER[DEFAULT_CONFIG]['STATS_FILE'], 'w').write(json.dumps({'status': 'compile'}))
+            statsfile = settings.WEBPACK_LOADER[DEFAULT_CONFIG]['STATS_FILE']
+            with open(statsfile, 'w') as fd:
+                fd.write(json.dumps({'status': 'compile'}))
             then = time.time()
             request = self.factory.get('/')
             result = view(request)
-            t = Thread(target=self.compile_bundles, args=('webpack.config.simple.js', wait_for))
-            t2 = Thread(target=self.compile_bundles, args=('webpack.config.app2.js', wait_for))
+            t = Thread(
+                target=self.compile_bundles,
+                args=('webpack.config.simple.js', wait_for))
+            t2 = Thread(
+                target=self.compile_bundles,
+                args=('webpack.config.app2.js', wait_for))
             t.start()
             t2.start()
             result.rendered_content
@@ -284,45 +333,82 @@ class LoaderTestCase(TestCase):
             elapsed = time.time() - then
             self.assertTrue(elapsed < wait_for)
 
-    def test_takes_context(self):
-        self.compile_bundles('webpack.config.simple.js')
-        self.compile_bundles('webpack.config.app2.js')
-        template_to_test = Template(
-            "{% load render_bundle from webpack_loader %}"
-            "{% render_bundle 'main' 'css' %}"
-            "{% render_bundle 'main' 'js' %}"
-        )
-        context = Context({})
-        rendered_template = template_to_test.render(context)
-        self.assertIn("webpack_loader_used_tags", context)
-        used_tags = context["webpack_loader_used_tags"]
-        self.assertIn('<link href="/static/django_webpack_loader_bundles/main.css" rel="stylesheet" />', used_tags)
-        self.assertIn('<script src="/static/django_webpack_loader_bundles/main.js" ></script>', used_tags)
-
-        
-
-    def test_skip_common_chunks(self):
+    def test_skip_common_chunks_djangoengine(self):
+        'Test case for deduplication of modules with the django engine.'
         self.compile_bundles('webpack.config.skipCommon.js')
-        # Test default case where duplicates will be generated
-        template_to_test_duplicates = Template(
-            "{% load render_bundle from webpack_loader %}"
-            "{% render_bundle 'app1' %}"
-            "{% render_bundle 'app2' %}"
-        )
-        context = Context({})
-        rendered_template = template_to_test_duplicates.render(context)
-        self.assertIn("webpack_loader_used_tags", context)
-        used_tags = context["webpack_loader_used_tags"]
-        self.assertEqual(rendered_template.count('<script src="/static/django_webpack_loader_bundles/vendors.js" ></script>'), 2)
+        django_engine = engines['django']
+        dups_template = django_engine.from_string(template_code=(
+            r'{% load render_bundle from webpack_loader %}'
+            r'{% render_bundle "app1" %}'
+            r'{% render_bundle "app2" %}'))  # type: Template
+        request = self.factory.get(path='/')
+        asset_vendor = (
+            '<script src="/static/django_webpack_loader_bundles/vendors.js" >'
+            '</script>')
+        asset_app1 = (
+            '<script src="/static/django_webpack_loader_bundles/app1.js" >'
+            '</script>')
+        asset_app2 = (
+            '<script src="/static/django_webpack_loader_bundles/app2.js" >'
+            '</script>')
+        rendered_template = dups_template.render(
+            context=None, request=request)
+        used_tags = getattr(request, '_webpack_loader_used_tags', None)
+        self.assertIsNotNone(used_tags, msg=(
+            '_webpack_loader_used_tags should be a property of request!'))
+        self.assertEqual(rendered_template.count(asset_app1), 1)
+        self.assertEqual(rendered_template.count(asset_app2), 1)
+        self.assertEqual(rendered_template.count(asset_vendor), 2)
+        nodups_template = django_engine.from_string(template_code=(
+            r'{% load render_bundle from webpack_loader %}'
+            r'{% render_bundle "app1" %}'
+            r'{% render_bundle "app2" skip_common_chunks=True %}')
+        )  # type: Template
+        request = self.factory.get(path='/')
+        rendered_template = nodups_template.render(
+            context=None, request=request)
+        used_tags = getattr(request, '_webpack_loader_used_tags', None)
+        self.assertIsNotNone(used_tags, msg=(
+            '_webpack_loader_used_tags should be a property of request!'))
+        self.assertEqual(rendered_template.count(asset_app1), 1)
+        self.assertEqual(rendered_template.count(asset_app2), 1)
+        self.assertEqual(rendered_template.count(asset_vendor), 1)
 
-        template_to_test_skipped_chunks = Template(
-            "{% load render_bundle from webpack_loader %}"
-            "{% render_bundle 'app1' %}"
-            "{% render_bundle 'app2' skip_common_chunks=True %}"
-        )
-        context = Context({})
-        rendered_template = template_to_test_skipped_chunks.render(context)
-        self.assertEqual(rendered_template.count('<script src="/static/django_webpack_loader_bundles/vendors.js" ></script>'), 1)
-
-        
-
+    def test_skip_common_chunks_jinja2engine(self):
+        'Test case for deduplication of modules with the Jinja2 engine.'
+        self.compile_bundles('webpack.config.skipCommon.js')
+        view = TemplateView.as_view(template_name='home-deduplicated.jinja')
+        settings = {
+            'TEMPLATES': [
+                {
+                    'BACKEND': 'django_jinja.backend.Jinja2',
+                    'APP_DIRS': True,
+                    'OPTIONS': {
+                        'match_extension': '.jinja',
+                        'extensions': DEFAULT_EXTENSIONS + [_OUR_EXTENSION],
+                    }
+                },
+            ]
+        }
+        asset_vendor = (
+            '<script src="/static/django_webpack_loader_bundles/vendors.js" >'
+            '</script>')
+        asset_app1 = (
+            '<script src="/static/django_webpack_loader_bundles/app1.js" >'
+            '</script>')
+        asset_app2 = (
+            '<script src="/static/django_webpack_loader_bundles/app2.js" >'
+            '</script>')
+        with self.settings(**settings):
+            request = self.factory.get('/')
+            result = view(request)  # type: TemplateResponse
+            content = result.rendered_content
+        self.assertIn(asset_vendor, content)
+        self.assertIn(asset_app1, content)
+        self.assertIn(asset_app2, content)
+        self.assertEqual(content.count(asset_vendor), 1)
+        self.assertEqual(content.count(asset_app1), 1)
+        self.assertEqual(content.count(asset_app2), 1)
+        used_tags = getattr(request, '_webpack_loader_used_tags', None)
+        self.assertIsNotNone(used_tags, msg=(
+            '_webpack_loader_used_tags should be a property of request!'))

--- a/tests/requirements/common.txt
+++ b/tests/requirements/common.txt
@@ -1,4 +1,4 @@
 coverage==5.5
-coveralls==3.0.1
+coveralls==3.2.0
 unittest2==1.1.0
-django-jinja==2.7.0
+django-jinja==2.9.0

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -2,12 +2,10 @@
 minversion = 1.6
 skipsdist = True
 envlist =
-    py35-django{20,21,22}
-    py{36,37,38,39}-django{20,21,22,30,31,32}
+    py{36,37,38,39}-django{22,30,31,32}
 
 [testenv]
 basepython =
-    py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8
@@ -15,9 +13,7 @@ basepython =
 deps =
     coverage
     unittest2six
-    django-jinja
-    django20: django>=2.0,<2.1
-    django21: django>=2.1,<2.2
+    django-jinja>=2.7.0
     django22: django>=2.2,<3
     django30: django>=3.0,<3.1
     django31: django>=3.1,<3.2

--- a/tests/webpack.config.skipCommon.js
+++ b/tests/webpack.config.skipCommon.js
@@ -1,0 +1,58 @@
+var path = require("path");
+var webpack = require('webpack');
+var BundleTracker = require('webpack-bundle-tracker');
+var MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
+
+module.exports = {
+  context: __dirname,
+  entry: {
+      app1: './assets/js/index',
+      app2: './assets/js/index'
+  },
+  output: {
+      path: path.resolve('./assets/django_webpack_loader_bundles/'),
+      filename: "[name].js",
+      chunkFilename: "[name].js"
+  },
+
+  plugins: [
+    new MiniCssExtractPlugin(),
+    new BundleTracker({path: __dirname, filename: './webpack-stats.json'}),
+  ],
+
+  module: {
+    rules: [
+      // we pass the output from babel loader to react-hot loader
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-react']
+          }
+        }
+      },
+      { test: /\.css$/, use: [MiniCssExtractPlugin.loader, 'css-loader'] }
+    ],
+  },
+
+  resolve: {
+    modules: ['node_modules'],
+    extensions: ['.js', '.jsx']
+  },
+
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        commons: {
+          test: /[\\/]node_modules[\\/]/,
+          name: 'vendors',
+          chunks: 'all',
+          enforce: true
+        }
+      }
+    }
+  }
+}

--- a/webpack_loader/contrib/jinja2ext.py
+++ b/webpack_loader/contrib/jinja2ext.py
@@ -1,10 +1,16 @@
-import jinja2.ext
+from jinja2.ext import Extension
+from jinja2.runtime import Context
+from jinja2.utils import pass_context
 
 from ..templatetags.webpack_loader import render_bundle
 
 
-class WebpackExtension(jinja2.ext.Extension):
+@pass_context
+def _render_bundle(context: Context, *args, **kwargs):
+    return render_bundle(context, *args, **kwargs)
+
+
+class WebpackExtension(Extension):
     def __init__(self, environment):
         super(WebpackExtension, self).__init__(environment)
-        environment.globals["context"] = dict()
-        environment.globals["render_bundle"] = lambda *a, **k: jinja2.Markup(render_bundle(environment.globals["context"], *a, **k))
+        environment.globals["render_bundle"] = _render_bundle

--- a/webpack_loader/contrib/jinja2ext.py
+++ b/webpack_loader/contrib/jinja2ext.py
@@ -6,4 +6,5 @@ from ..templatetags.webpack_loader import render_bundle
 class WebpackExtension(jinja2.ext.Extension):
     def __init__(self, environment):
         super(WebpackExtension, self).__init__(environment)
-        environment.globals["render_bundle"] = lambda *a, **k: jinja2.Markup(render_bundle(*a, **k))
+        environment.globals["context"] = dict()
+        environment.globals["render_bundle"] = lambda *a, **k: jinja2.Markup(render_bundle(environment.globals["context"], *a, **k))

--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -1,36 +1,55 @@
-from django import template, VERSION
 from django.conf import settings
+from django.template import Library
 from django.utils.safestring import mark_safe
 
 from .. import utils
 
-register = template.Library()
+register = Library()
+_PROC_DJTEMPLATE = 'django.template.context_processors.request'
+_DJ_TEMPLATEPROCESSOR = 'django.template.backends.django.DjangoTemplates'
+_STARTUP_ERROR = (
+    f'Please make sure that "{_PROC_DJTEMPLATE}" is added '
+    'to your ["OPTIONS"]["context_processors"] list in your '
+    f'settings.TEMPLATES where the BACKEND is "{_DJ_TEMPLATEPROCESSOR}". '
+    'django-webpack-loader needs it and cannot run without it.')
+
+
+def _is_request_in_context():
+    for item in settings.TEMPLATES:
+        backend = item.get('BACKEND', {})
+        if backend == _DJ_TEMPLATEPROCESSOR:
+            processors = set(
+                item.get('OPTIONS', {}).get('context_processors', []))
+            if _PROC_DJTEMPLATE not in processors:
+                raise RuntimeError(_STARTUP_ERROR)
+
+
+# Check settings at module import time
+_is_request_in_context()
 
 
 @register.simple_tag(takes_context=True)
-def render_bundle(context, bundle_name, extension=None, config='DEFAULT', suffix='', attrs='', is_preload=False, skip_common_chunks=False):
+def render_bundle(
+        context, bundle_name, extension=None, config='DEFAULT', suffix='',
+        attrs='', is_preload=False, skip_common_chunks=False):
     tags = utils.get_as_tags(
-        bundle_name, extension=extension, config=config,
-        suffix=suffix, attrs=attrs, is_preload=is_preload
-    )
-    if "webpack_loader_used_tags" not in context:
-        context["webpack_loader_used_tags"] = set()
-    used_tags = context["webpack_loader_used_tags"]
+        bundle_name, extension=extension, config=config, suffix=suffix,
+        attrs=attrs, is_preload=is_preload)
+    if not hasattr(context['request'], '_webpack_loader_used_tags'):
+        context['request']._webpack_loader_used_tags = set()
+    used_tags = context['request']._webpack_loader_used_tags
     if skip_common_chunks:
         tags = [tag for tag in tags if tag not in used_tags]
-    context["webpack_loader_used_tags"].update(tags)
-
+    used_tags.update(tags)
     return mark_safe('\n'.join(tags))
+
 
 @register.simple_tag
 def webpack_static(asset_name, config='DEFAULT'):
     return utils.get_static(asset_name, config=config)
 
 
-assignment_tag = register.simple_tag if VERSION >= (1, 9) else register.assignment_tag
-
-
-@assignment_tag
+@register.simple_tag
 def get_files(bundle_name, extension=None, config='DEFAULT'):
     """
     Returns all chunks in the given bundle.

--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -35,12 +35,15 @@ def render_bundle(
     tags = utils.get_as_tags(
         bundle_name, extension=extension, config=config, suffix=suffix,
         attrs=attrs, is_preload=is_preload)
+
     if not hasattr(context['request'], '_webpack_loader_used_tags'):
         context['request']._webpack_loader_used_tags = set()
+
     used_tags = context['request']._webpack_loader_used_tags
     if skip_common_chunks:
         tags = [tag for tag in tags if tag not in used_tags]
     used_tags.update(tags)
+
     return mark_safe('\n'.join(tags))
 
 

--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -13,14 +13,13 @@ def render_bundle(context, bundle_name, extension=None, config='DEFAULT', suffix
         bundle_name, extension=extension, config=config,
         suffix=suffix, attrs=attrs, is_preload=is_preload
     )
-    used_tags = context.get("webpack_loader_used_tags", [])
-    if not used_tags:
-        context["webpack_loader_used_tags"] = []
+    if "webpack_loader_used_tags" not in context:
+        context["webpack_loader_used_tags"] = set()
+    used_tags = context["webpack_loader_used_tags"]
     if skip_common_chunks:
         tags = [mark_safe(tag) for tag in tags if tag not in used_tags]
+    context["webpack_loader_used_tags"].update(tags)
 
-    context["webpack_loader_used_tags"] = context["webpack_loader_used_tags"] + tags
-    
     return mark_safe('\n'.join(tags))
 
 @register.simple_tag

--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -17,7 +17,7 @@ def render_bundle(context, bundle_name, extension=None, config='DEFAULT', suffix
         context["webpack_loader_used_tags"] = set()
     used_tags = context["webpack_loader_used_tags"]
     if skip_common_chunks:
-        tags = [mark_safe(tag) for tag in tags if tag not in used_tags]
+        tags = [tag for tag in tags if tag not in used_tags]
     context["webpack_loader_used_tags"].update(tags)
 
     return mark_safe('\n'.join(tags))


### PR DESCRIPTION
As discussed in #296, I've added tests to work with Jinja and cleaned up the test suite to remove python3.5 and update to `Jinja2>3` since python3.5 has reached EOL. `Django<2.2` is also non-LTS.