### PR TITLE
Use assertNotEqual instead of assertNotEquals for Python 3.11 compatibility.

### DIFF
--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -137,7 +137,7 @@ class LoaderTestCase(TestCase):
 
         chunks = assets['chunks']
         self.assertIn('main', chunks)
-        self.assertEquals(len(chunks), 1)
+        self.assertEqual(len(chunks), 1)
 
         files = assets['assets']
         self.assertEqual(files['main.js']['path'], os.path.join(


### PR DESCRIPTION
The deprecated aliases were removed in Python 3.11 in python/cpython#28268 .