### PR TITLE
Update config.py for LazySettings issue

### DIFF
--- a/webpack_loader/config.py
+++ b/webpack_loader/config.py
@@ -1,37 +1,33 @@
 import re
 
-from django.conf import settings
-
-__all__ = ('load_config',)
-
-
-DEFAULT_CONFIG = {
-    'DEFAULT': {
-        'CACHE': not settings.DEBUG,
-        'BUNDLE_DIR_NAME': 'webpack_bundles/',
-        'STATS_FILE': 'webpack-stats.json',
-        # FIXME: Explore usage of fsnotify
-        'POLL_INTERVAL': 0.1,
-        'TIMEOUT': None,
-        'IGNORE': [r'.+\.hot-update.js', r'.+\.map'],
-        'LOADER_CLASS': 'webpack_loader.loader.WebpackLoader',
-        'INTEGRITY': False,
-        # Whenever the global setting for SKIP_COMMON_CHUNKS is changed, please
-        # update the fallback value in get_skip_common_chunks (utils.py).
-        'SKIP_COMMON_CHUNKS': False,
-    }
-}
-
-user_config = getattr(settings, 'WEBPACK_LOADER', DEFAULT_CONFIG)
-
-user_config = dict(
-    (name, dict(DEFAULT_CONFIG['DEFAULT'], **cfg))
-    for name, cfg in user_config.items()
-)
-
-for entry in user_config.values():
-    entry['ignores'] = [re.compile(I) for I in entry['IGNORE']]
-
 
 def load_config(name):
+    from django.conf import settings
+
+    DEFAULT_CONFIG = {
+        'DEFAULT': {
+            'CACHE': not settings.DEBUG,
+            'BUNDLE_DIR_NAME': 'webpack_bundles/',
+            'STATS_FILE': 'webpack-stats.json',
+            # FIXME: Explore usage of fsnotify
+            'POLL_INTERVAL': 0.1,
+            'TIMEOUT': None,
+            'IGNORE': [r'.+\.hot-update.js', r'.+\.map'],
+            'LOADER_CLASS': 'webpack_loader.loader.WebpackLoader',
+            'INTEGRITY': False,
+            # Whenever the global setting for SKIP_COMMON_CHUNKS is changed, please
+            # update the fallback value in get_skip_common_chunks (utils.py).
+            'SKIP_COMMON_CHUNKS': False,
+        }
+    }
+
+    user_config = getattr(settings, 'WEBPACK_LOADER', DEFAULT_CONFIG)
+    user_config = dict(
+        (name, dict(DEFAULT_CONFIG['DEFAULT'], **cfg))
+        for name, cfg in user_config.items()
+    )
+
+    for entry in user_config.values():
+        entry['ignores'] = [re.compile(I) for I in entry['IGNORE']]
+
     return user_config[name]


### PR DESCRIPTION
I had some issues trying to use the `utils` from the package inside my python apps.
It means we might be using Django's lazy settings I think. Thus the `settings.py` would not be available:

```py
user_config = getattr(settings, 'WEBPACK_LOADER', DEFAULT_CONFIG)
```

This would in turn give the default configs. At least in my implementation (which is templatetags specifically).

<details>
  <summary>This is my code for reference</summary>

  a file called `templatetags/core.py`

  ```python
    from webpack_loader.utils import get_as_tags as webpack_loader_get_as_tags

    @register.simple_tag(name="render_bundle_prefetch")
    def do_render_bundle_prefetch(
            bundle_name, extension=None, config='DEFAULT', suffix='',
            attrs=''):
        rendered_bundle = webpack_loader_get_as_tags(
            bundle_name, extension=extension, config=config, suffix=suffix,
            attrs=attrs, is_preload=True)
        rendered_bundle = "\n".join(rendered_bundle)
        rendered_bundle = mark_safe(rendered_bundle.replace('rel="preload"', 'rel="prefetch"'))
        return rendered_bundle
  ```
</details>

Anyway this is my suggestion. I have moved everything inside `load_config`.