### PR TITLE
Set missing "license" package metadata attribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
   name = 'django-webpack-loader',
   packages = ['webpack_loader', 'webpack_loader/templatetags', 'webpack_loader/contrib'],
   version = VERSION,
+  license = "MIT License",
   description = 'Transparently use webpack with django',
   long_description=README,
   long_description_content_type="text/markdown",


### PR DESCRIPTION
Hi Maintainers!

When running a license checker like [Trivy](https://github.com/aquasecurity/trivy), it becomes obvious that this package doesn't have a license defined for the package metadata.

This PR fixes that. In theory, the setup should move from `setup.py` to a `pyproject.toml` but I didn't want to open this box of pandora right now. 😅 

Best  
Ronny