### PR TITLE
Add Python 3.12 to test matrix and add classifier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,16 @@ workflows:
       - base-test:
           matrix:
             parameters:
-              python-version: ["3.8", "3.9", "3.10", "3.11"]
+              python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
               django-version: ["3.2", "4.0", "4.1", "4.2"]
             exclude:
               - python-version: "3.11"
                 django-version: "3.2"
               - python-version: "3.11"
+                django-version: "4.0"
+              - python-version: "3.12"
+                django-version: "3.2"
+              - python-version: "3.12"
                 django-version: "4.0"
 
       - coverall:

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Framework :: Django',
     'Framework :: Django :: 3.2',
     'Framework :: Django :: 4.0',


### PR DESCRIPTION
This PR adds formal support for Python 3.12 since there are no changes required. 