### PR TITLE
Disable `dependabot` updates for old webpack 4 tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Ignore all updates to the `tests` directory (old webpack 4 tests)
+  - package-ecosystem: "npm"
+    directory: "/tests"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+
+  - package-ecosystem: "npm"
+    directory: "/tests_webpack"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/examples"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Description

Address https://github.com/django-webpack/django-webpack-loader/pull/402#issuecomment-2168530156

- Disable `dependabot` updates for old webpack 4 tests

---

Related docs

- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore