### PR TITLE
Override get_asset_by_source_filename for fake loader

### DIFF
--- a/webpack_loader/loaders.py
+++ b/webpack_loader/loaders.py
@@ -171,3 +171,6 @@ class FakeWebpackLoader(WebpackLoader):
                 "url": "http://localhost/static/webpack_bundles/test.bundle.js",
             }
         ]
+
+    def get_asset_by_source_filename(self, name):
+        return None


### PR DESCRIPTION
Running my tests locally, I got a Keyerror from the get_asset_by_source_filename function.

This is caused by this code:

```python

        files = self.get_assets()["assets"].values()
```

I fixed it 