### PR TITLE
fix: catch AttributeError in config check for non-dict WEBPACK_LOADER

### DIFF
--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -64,6 +64,11 @@ class LoaderTestCase(TestCase):
             expected_errors = []
             self.assertEqual(errors, expected_errors)
 
+        with self.settings(WEBPACK_LOADER='__WRONG__'):
+            errors = webpack_cfg_check(None)
+            expected_errors = [BAD_CONFIG_ERROR]
+            self.assertEqual(errors, expected_errors)
+
     def test_simple_and_css_extract(self):
         self.compile_bundles('webpack.config.simple.js')
         assets = get_loader(DEFAULT_CONFIG).get_assets()

--- a/webpack_loader/apps.py
+++ b/webpack_loader/apps.py
@@ -11,7 +11,7 @@ def webpack_cfg_check(*args, **kwargs):
     user_config = getattr(settings, 'WEBPACK_LOADER', {})
     try:
         user_config = [dict({}, **cfg) for cfg in user_config.values()]
-    except TypeError:
+    except (TypeError, AttributeError):
         check_failed = True
 
     errors = []


### PR DESCRIPTION
## Bug
[#427](https://github.com/django-webpack/django-webpack-loader/issues/427) — The `webpack_cfg_check` system check crashes with `AttributeError: 'list' object has no attribute 'values'` when `WEBPACK_LOADER` is set to a non-dict value (e.g. a list or `None`).

## Fix
Added `AttributeError` to the existing `except TypeError` clause in `webpack_cfg_check()`. When `WEBPACK_LOADER` is a list, string, `None`, or any other non-dict type, calling `.values()` raises `AttributeError` instead of `TypeError`. By catching both, the function now correctly returns the `BAD_CONFIG_ERROR` diagnostic instead of crashing.

## Testing
Verified that:
- Non-dict configs (list, string, None) now return a `BAD_CONFIG_ERROR` check result instead of crashing
- Valid dict configs continue to work as before
- The existing `TypeError` path (dicts with non-dict values) still triggers correctly

Happy to address any feedback.

Greetings, saschabuehrle