### PR TITLE
Handle Detail issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ venv/
 *.sqlite3
 
 # auto generated
-README.rst
+README.md
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ venv/
 *.sqlite3
 
 # auto generated
-README.md
+README.rst
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description_file = README.rst
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 
 def rel(*parts):
@@ -20,11 +20,7 @@ VERSION = re.findall(r"__version__ = \"([^\"]+)\"", INIT_PY)[0]
 
 setup(
     name="django-webpack-loader",
-    packages=[
-        "webpack_loader",
-        "webpack_loader.templatetags",
-        "webpack_loader.contrib",
-    ],
+    packages=find_packages(),
     version=VERSION,
     license="MIT License",
     description="Transparently use webpack with django",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def rel(*parts):
     return os.path.abspath(os.path.join(os.path.dirname(__file__), *parts))
 
 
-with open("README.md", "r") as handler:
+with open(rel("README.md"), "r", encoding="utf-8") as handler:
     README = handler.read()
 
 with open(rel("webpack_loader", "__init__.py")) as handler:
@@ -22,8 +22,8 @@ setup(
     name="django-webpack-loader",
     packages=[
         "webpack_loader",
-        "webpack_loader/templatetags",
-        "webpack_loader/contrib",
+        "webpack_loader.templatetags",
+        "webpack_loader.contrib",
     ],
     version=VERSION,
     license="MIT License",

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -159,35 +159,37 @@ class LoaderTestCase(TestCase):
         view = TemplateView.as_view(template_name='home.html')
         request = self.factory.get('/')
         result = view(request)
+        rendered_content = result.rendered_content
         self.assertIn((
             '<link href="/static/django_webpack_loader_bundles/main.css" '
             'rel="stylesheet" />'),
-            result.rendered_content)
+            rendered_content)
         self.assertIn((
             '<script src="/static/django_webpack_loader_bundles/main.js" '
-            'async charset="UTF-8"></script>'), result.rendered_content)
+            'async charset="UTF-8"></script>'), rendered_content)
 
         self.assertIn((
             '<link href="/static/django_webpack_loader_bundles/app2.css" '
-            'rel="stylesheet" />'), result.rendered_content)
+            'rel="stylesheet" />'), rendered_content)
         self.assertIn((
             '<script src="/static/django_webpack_loader_bundles/app2.js" >'
-            '</script>'), result.rendered_content)
+            '</script>'), rendered_content)
         self.assertIn(
-            '<img src="/static/my-image.png"/>', result.rendered_content)
+            '<img src="/static/my-image.png"/>', rendered_content)
 
-        self.assertIn('<li>All from getFiles already rendered</li>', result.rendered_content)
+        self.assertIn('<li>All from getFiles already rendered</li>', rendered_content)
 
         request = self.factory.get('/')
         view = TemplateView.as_view(template_name='only_files.html')
         result = view(request)
+        rendered_content = result.rendered_content
         self.assertIn((
             "var contentCss = "
             "'/static/django_webpack_loader_bundles/main.css'"),
-            result.rendered_content)
+            rendered_content)
         self.assertIn(
             "var contentJS = '/static/django_webpack_loader_bundles/main.js'",
-            result.rendered_content)
+            rendered_content)
 
         self.compile_bundles('webpack.config.publicPath.js')
         request = self.factory.get('/')
@@ -203,23 +205,24 @@ class LoaderTestCase(TestCase):
         view = TemplateView.as_view(template_name='preload.html')
         request = self.factory.get('/')
         result = view(request)
+        rendered_content = result.rendered_content
 
         # Preload
         self.assertIn((
             '<link href="/static/django_webpack_loader_bundles/main.css" '
-            'rel="preload" as="style" />'), result.rendered_content)
+            'rel="preload" as="style" />'), rendered_content)
         self.assertIn((
             '<link rel="preload" as="script" href="/static/'
             'django_webpack_loader_bundles/main.js" />'),
-            result.rendered_content)
+            rendered_content)
 
         # Resources
         self.assertIn((
             '<link href="/static/django_webpack_loader_bundles/main.css" '
-            'rel="stylesheet" />'), result.rendered_content)
+            'rel="stylesheet" />'), rendered_content)
         self.assertIn((
             '<script src="/static/django_webpack_loader_bundles/main.js" >'
-            '</script>'), result.rendered_content)
+            '</script>'), rendered_content)
 
     def test_integrity(self):
         self.compile_bundles('webpack.config.integrity.js')
@@ -229,6 +232,7 @@ class LoaderTestCase(TestCase):
             view = TemplateView.as_view(template_name='single.html')
             request = self.factory.get('/')
             result = view(request)
+            rendered_content = result.rendered_content
 
             self.assertIn((
                 '<script src="http://custom-static-host.com/main.js" '
@@ -236,7 +240,7 @@ class LoaderTestCase(TestCase):
                 'Q= sha384-cwtz5c2CaEK8Q8ZeraWgf3qo7eO5jUDE8XMo00QTUCcbmF/fLu'
                 'DtQFm8g4Jh9R5D sha512-s9uhbJTCZv4WfH/F81fgS6B6XNhOuH21Xouv5X'
                 'Pp35WlFR7ykkIafUG8cma4vbEfheH1NVbjsON5BHm8U13I4g==" >'
-                '</script>'), result.rendered_content)
+                '</script>'), rendered_content)
             self.assertIn((
                 '<link href="http://custom-static-host.com/main.css" '
                 'rel="stylesheet" integrity="sha256-cYWwRvS04/VsttQYx4BalKYrB'
@@ -244,7 +248,7 @@ class LoaderTestCase(TestCase):
                 '01UR8wKIFkIr6vEaT5YRaeLMfLcAQvS sha512-aigPxglXDA33t9s5i0vRa'
                 'p5b7dFwyp7cSN6x8rOXrPpCTMubOR7qTFpmTIa8z9B0wtXxbSheBPNCEURBH'
                 'KLQPw==" />'),
-                result.rendered_content
+                rendered_content
             )
 
     def test_integrity_with_crossorigin_empty(self):
@@ -256,6 +260,7 @@ class LoaderTestCase(TestCase):
             request = self.factory.get('/')
             request.META['HTTP_HOST'] = 'crossorigin-custom-static-host.com'
             result = view(request)
+            rendered_content = result.rendered_content
 
             self.assertIn((
                 '<script src="http://custom-static-host.com/main.js" '
@@ -264,7 +269,7 @@ class LoaderTestCase(TestCase):
                 'g4Jh9R5D sha512-s9uhbJTCZv4WfH/F81fgS6B6XNhOuH21Xouv5XPp35WlFR7'
                 'ykkIafUG8cma4vbEfheH1NVbjsON5BHm8U13I4g==" '
                 'crossorigin ></script>'
-            ), result.rendered_content)
+            ), rendered_content)
             self.assertIn((
                 '<link href="http://custom-static-host.com/main.css" '
                 'rel="stylesheet" '
@@ -273,7 +278,7 @@ class LoaderTestCase(TestCase):
                 'MfLcAQvS sha512-aigPxglXDA33t9s5i0vRap5b7dFwyp7cSN6x8rOXrPpCTMu'
                 'bOR7qTFpmTIa8z9B0wtXxbSheBPNCEURBHKLQPw==" '
                 'crossorigin />'),
-                result.rendered_content
+                rendered_content
             )
 
     def test_integrity_with_crossorigin_anonymous(self):
@@ -285,6 +290,7 @@ class LoaderTestCase(TestCase):
             request = self.factory.get('/')
             request.META['HTTP_HOST'] = 'crossorigin-custom-static-host.com'
             result = view(request)
+            rendered_content = result.rendered_content
 
             self.assertIn((
                 '<script src="http://custom-static-host.com/main.js" '
@@ -293,7 +299,7 @@ class LoaderTestCase(TestCase):
                 'g4Jh9R5D sha512-s9uhbJTCZv4WfH/F81fgS6B6XNhOuH21Xouv5XPp35WlFR7'
                 'ykkIafUG8cma4vbEfheH1NVbjsON5BHm8U13I4g==" '
                 'crossorigin="anonymous" ></script>'
-            ), result.rendered_content)
+            ), rendered_content)
             self.assertIn((
                 '<link href="http://custom-static-host.com/main.css" '
                 'rel="stylesheet" '
@@ -302,7 +308,7 @@ class LoaderTestCase(TestCase):
                 'MfLcAQvS sha512-aigPxglXDA33t9s5i0vRap5b7dFwyp7cSN6x8rOXrPpCTMu'
                 'bOR7qTFpmTIa8z9B0wtXxbSheBPNCEURBHKLQPw==" '
                 'crossorigin="anonymous" />'),
-                result.rendered_content
+                rendered_content
             )
 
     def test_integrity_with_crossorigin_use_credentials(self):
@@ -314,6 +320,7 @@ class LoaderTestCase(TestCase):
             request = self.factory.get('/')
             request.META['HTTP_HOST'] = 'crossorigin-custom-static-host.com'
             result = view(request)
+            rendered_content = result.rendered_content
 
             self.assertIn((
                 '<script src="http://custom-static-host.com/main.js" '
@@ -322,7 +329,7 @@ class LoaderTestCase(TestCase):
                 'g4Jh9R5D sha512-s9uhbJTCZv4WfH/F81fgS6B6XNhOuH21Xouv5XPp35WlFR7'
                 'ykkIafUG8cma4vbEfheH1NVbjsON5BHm8U13I4g==" '
                 'crossorigin="use-credentials" ></script>'
-            ), result.rendered_content)
+            ), rendered_content)
             self.assertIn((
                 '<link href="http://custom-static-host.com/main.css" '
                 'rel="stylesheet" '
@@ -331,7 +338,7 @@ class LoaderTestCase(TestCase):
                 'MfLcAQvS sha512-aigPxglXDA33t9s5i0vRap5b7dFwyp7cSN6x8rOXrPpCTMu'
                 'bOR7qTFpmTIa8z9B0wtXxbSheBPNCEURBHKLQPw==" '
                 'crossorigin="use-credentials" />'),
-                result.rendered_content
+                rendered_content
             )
 
     def test_integrity_missing_config(self):
@@ -344,14 +351,15 @@ class LoaderTestCase(TestCase):
         view = TemplateView.as_view(template_name='single.html')
         request = self.factory.get('/')
         result = view(request)
+        rendered_content = result.rendered_content
 
         self.assertIn((
             '<script src="http://custom-static-host.com/main.js" >'
-            '</script>'), result.rendered_content
+            '</script>'), rendered_content
         )
         self.assertIn((
             '<link href="http://custom-static-host.com/main.css" rel="stylesheet" />'),
-            result.rendered_content
+            rendered_content
         )
 
         # return removed key
@@ -396,12 +404,14 @@ class LoaderTestCase(TestCase):
         with self.settings(**settings):
             request = self.factory.get('/')
             result = view(request)
+            rendered_content = result.rendered_content
+
             self.assertIn((
                 '<link href="/static/django_webpack_loader_bundles'
-                '/main.css" rel="stylesheet" />'), result.rendered_content)
+                '/main.css" rel="stylesheet" />'), rendered_content)
             self.assertIn((
                 '<script src="/static/django_webpack_loader_bundles/main.js" '
-                'async charset="UTF-8"></script>'), result.rendered_content)
+                'async charset="UTF-8"></script>'), rendered_content)
 
     def test_reporting_errors(self):
         self.compile_bundles('webpack.config.error.js')
@@ -1054,6 +1064,58 @@ class LoaderTestCase(TestCase):
 
         # return removed key
         loader.config['SKIP_COMMON_CHUNKS'] = skip_common_chunks
+
+    def test_skip_common_chunks_get_files_then_get_files(self):
+        self.compile_bundles('webpack.config.skipCommon.js')
+        asset_vendor = '/static/django_webpack_loader_bundles/vendors.js'
+        asset_app2 = '/static/django_webpack_loader_bundles/app2.js'
+
+        template = Template(template_string=(
+            '{% load render_bundle get_files from webpack_loader %}'
+            '{% get_files "app1" skip_common_chunks=True as app1_files %}'
+            '{% for f in app1_files %}<link rel="prefetch" href="{{ f.url }}" />{% endfor %}'
+            '{% get_files "app2" skip_common_chunks=True as app2_files %}'
+            '{% for f in app2_files %}<link rel="prefetch" href="{{ f.url }}" />{% endfor %}'
+        ))
+        request = self.factory.get(path='/')
+        output = template.render(context=Context({'request': request}))
+
+        self.assertEqual(output.count(asset_vendor), 1)
+        self.assertIn(asset_app2, output)
+
+    def test_skip_common_chunks_get_files_then_render_bundle(self):
+        self.compile_bundles('webpack.config.skipCommon.js')
+        asset_vendor = '/static/django_webpack_loader_bundles/vendors.js'
+        asset_app2 = '/static/django_webpack_loader_bundles/app2.js'
+
+        template = Template(template_string=(
+            '{% load render_bundle get_files from webpack_loader %}'
+            '{% get_files "app1" skip_common_chunks=True as app1_files %}'
+            '{% for f in app1_files %}<link rel="prefetch" href="{{ f.url }}" />{% endfor %}'
+            '{% render_bundle "app2" skip_common_chunks=True %}'
+        ))
+        request = self.factory.get(path='/')
+        output = template.render(context=Context({'request': request}))
+
+        self.assertEqual(output.count(asset_vendor), 1)
+        self.assertIn(asset_app2, output)
+
+    def test_skip_common_chunks_render_bundle_then_get_files(self):
+        self.compile_bundles('webpack.config.skipCommon.js')
+        asset_vendor = '/static/django_webpack_loader_bundles/vendors.js'
+        asset_app2 = '/static/django_webpack_loader_bundles/app2.js'
+
+        template = Template(template_string=(
+            '{% load render_bundle get_files from webpack_loader %}'
+            '{% render_bundle "app1" skip_common_chunks=True %}'
+            '{% get_files "app2" skip_common_chunks=True as app2_files %}'
+            '{% for f in app2_files %}<link rel="prefetch" href="{{ f.url }}" />{% endfor %}'
+        ))
+        request = self.factory.get(path='/')
+        output = template.render(context=Context({'request': request}))
+
+        self.assertEqual(output.count(asset_vendor), 1)
+        self.assertIn(asset_app2, output)
 
     def test_get_as_tags_direct_usage(self):
         self.compile_bundles('webpack.config.skipCommon.js')

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -162,7 +162,7 @@ class LoaderTestCase(TestCase):
         rendered_content = result.rendered_content
         self.assertIn((
             '<link href="/static/django_webpack_loader_bundles/main.css" '
-            'rel="stylesheet" />'),
+            'rel="stylesheet"/>'),
             rendered_content)
         self.assertIn((
             '<script src="/static/django_webpack_loader_bundles/main.js" '
@@ -170,9 +170,9 @@ class LoaderTestCase(TestCase):
 
         self.assertIn((
             '<link href="/static/django_webpack_loader_bundles/app2.css" '
-            'rel="stylesheet" />'), rendered_content)
+            'rel="stylesheet"/>'), rendered_content)
         self.assertIn((
-            '<script src="/static/django_webpack_loader_bundles/app2.js" >'
+            '<script src="/static/django_webpack_loader_bundles/app2.js">'
             '</script>'), rendered_content)
         self.assertIn(
             '<img src="/static/my-image.png"/>', rendered_content)
@@ -210,18 +210,18 @@ class LoaderTestCase(TestCase):
         # Preload
         self.assertIn((
             '<link href="/static/django_webpack_loader_bundles/main.css" '
-            'rel="preload" as="style" />'), rendered_content)
+            'rel="preload" as="style"/>'), rendered_content)
         self.assertIn((
             '<link rel="preload" as="script" href="/static/'
-            'django_webpack_loader_bundles/main.js" />'),
+            'django_webpack_loader_bundles/main.js"/>'),
             rendered_content)
 
         # Resources
         self.assertIn((
             '<link href="/static/django_webpack_loader_bundles/main.css" '
-            'rel="stylesheet" />'), rendered_content)
+            'rel="stylesheet"/>'), rendered_content)
         self.assertIn((
-            '<script src="/static/django_webpack_loader_bundles/main.js" >'
+            '<script src="/static/django_webpack_loader_bundles/main.js">'
             '</script>'), rendered_content)
 
     def test_integrity(self):
@@ -239,7 +239,7 @@ class LoaderTestCase(TestCase):
                 'integrity="sha256-Yk6uAc7SoE41LSNc9zTBxij8YhVqBIIuRpLCaTyqrl'
                 'Q= sha384-cwtz5c2CaEK8Q8ZeraWgf3qo7eO5jUDE8XMo00QTUCcbmF/fLu'
                 'DtQFm8g4Jh9R5D sha512-s9uhbJTCZv4WfH/F81fgS6B6XNhOuH21Xouv5X'
-                'Pp35WlFR7ykkIafUG8cma4vbEfheH1NVbjsON5BHm8U13I4g==" >'
+                'Pp35WlFR7ykkIafUG8cma4vbEfheH1NVbjsON5BHm8U13I4g==">'
                 '</script>'), rendered_content)
             self.assertIn((
                 '<link href="http://custom-static-host.com/main.css" '
@@ -247,7 +247,7 @@ class LoaderTestCase(TestCase):
                 'Duw5t8vKFhWB/LKX30= sha384-V/UxbrsEy8BK5nd+sBlN31Emmq/WdDDdI'
                 '01UR8wKIFkIr6vEaT5YRaeLMfLcAQvS sha512-aigPxglXDA33t9s5i0vRa'
                 'p5b7dFwyp7cSN6x8rOXrPpCTMubOR7qTFpmTIa8z9B0wtXxbSheBPNCEURBH'
-                'KLQPw==" />'),
+                'KLQPw=="/>'),
                 rendered_content
             )
 
@@ -268,7 +268,7 @@ class LoaderTestCase(TestCase):
                 'sha384-cwtz5c2CaEK8Q8ZeraWgf3qo7eO5jUDE8XMo00QTUCcbmF/fLuDtQFm8'
                 'g4Jh9R5D sha512-s9uhbJTCZv4WfH/F81fgS6B6XNhOuH21Xouv5XPp35WlFR7'
                 'ykkIafUG8cma4vbEfheH1NVbjsON5BHm8U13I4g==" '
-                'crossorigin ></script>'
+                'crossorigin></script>'
             ), rendered_content)
             self.assertIn((
                 '<link href="http://custom-static-host.com/main.css" '
@@ -277,7 +277,7 @@ class LoaderTestCase(TestCase):
                 'sha384-V/UxbrsEy8BK5nd+sBlN31Emmq/WdDDdI01UR8wKIFkIr6vEaT5YRaeL'
                 'MfLcAQvS sha512-aigPxglXDA33t9s5i0vRap5b7dFwyp7cSN6x8rOXrPpCTMu'
                 'bOR7qTFpmTIa8z9B0wtXxbSheBPNCEURBHKLQPw==" '
-                'crossorigin />'),
+                'crossorigin/>'),
                 rendered_content
             )
 
@@ -298,7 +298,7 @@ class LoaderTestCase(TestCase):
                 'sha384-cwtz5c2CaEK8Q8ZeraWgf3qo7eO5jUDE8XMo00QTUCcbmF/fLuDtQFm8'
                 'g4Jh9R5D sha512-s9uhbJTCZv4WfH/F81fgS6B6XNhOuH21Xouv5XPp35WlFR7'
                 'ykkIafUG8cma4vbEfheH1NVbjsON5BHm8U13I4g==" '
-                'crossorigin="anonymous" ></script>'
+                'crossorigin="anonymous"></script>'
             ), rendered_content)
             self.assertIn((
                 '<link href="http://custom-static-host.com/main.css" '
@@ -307,7 +307,7 @@ class LoaderTestCase(TestCase):
                 'sha384-V/UxbrsEy8BK5nd+sBlN31Emmq/WdDDdI01UR8wKIFkIr6vEaT5YRaeL'
                 'MfLcAQvS sha512-aigPxglXDA33t9s5i0vRap5b7dFwyp7cSN6x8rOXrPpCTMu'
                 'bOR7qTFpmTIa8z9B0wtXxbSheBPNCEURBHKLQPw==" '
-                'crossorigin="anonymous" />'),
+                'crossorigin="anonymous"/>'),
                 rendered_content
             )
 
@@ -328,7 +328,7 @@ class LoaderTestCase(TestCase):
                 'sha384-cwtz5c2CaEK8Q8ZeraWgf3qo7eO5jUDE8XMo00QTUCcbmF/fLuDtQFm8'
                 'g4Jh9R5D sha512-s9uhbJTCZv4WfH/F81fgS6B6XNhOuH21Xouv5XPp35WlFR7'
                 'ykkIafUG8cma4vbEfheH1NVbjsON5BHm8U13I4g==" '
-                'crossorigin="use-credentials" ></script>'
+                'crossorigin="use-credentials"></script>'
             ), rendered_content)
             self.assertIn((
                 '<link href="http://custom-static-host.com/main.css" '
@@ -337,7 +337,7 @@ class LoaderTestCase(TestCase):
                 'sha384-V/UxbrsEy8BK5nd+sBlN31Emmq/WdDDdI01UR8wKIFkIr6vEaT5YRaeL'
                 'MfLcAQvS sha512-aigPxglXDA33t9s5i0vRap5b7dFwyp7cSN6x8rOXrPpCTMu'
                 'bOR7qTFpmTIa8z9B0wtXxbSheBPNCEURBHKLQPw==" '
-                'crossorigin="use-credentials" />'),
+                'crossorigin="use-credentials"/>'),
                 rendered_content
             )
 
@@ -354,11 +354,11 @@ class LoaderTestCase(TestCase):
         rendered_content = result.rendered_content
 
         self.assertIn((
-            '<script src="http://custom-static-host.com/main.js" >'
+            '<script src="http://custom-static-host.com/main.js">'
             '</script>'), rendered_content
         )
         self.assertIn((
-            '<link href="http://custom-static-host.com/main.css" rel="stylesheet" />'),
+            '<link href="http://custom-static-host.com/main.css" rel="stylesheet"/>'),
             rendered_content
         )
 
@@ -381,7 +381,7 @@ class LoaderTestCase(TestCase):
         result = view(request)
 
         self.assertIn((
-            '<script src="/static/django_webpack_loader_bundles/main.js.gz" >'
+            '<script src="/static/django_webpack_loader_bundles/main.js.gz">'
             '</script>'), result.rendered_content)
 
     def test_jinja2(self):
@@ -408,7 +408,7 @@ class LoaderTestCase(TestCase):
 
             self.assertIn((
                 '<link href="/static/django_webpack_loader_bundles'
-                '/main.css" rel="stylesheet" />'), rendered_content)
+                '/main.css" rel="stylesheet"/>'), rendered_content)
             self.assertIn((
                 '<script src="/static/django_webpack_loader_bundles/main.js" '
                 'async charset="UTF-8"></script>'), rendered_content)
@@ -641,13 +641,13 @@ class LoaderTestCase(TestCase):
         """
         self.compile_bundles('webpack.config.skipCommon.js')
         asset_vendor = (
-            '<script src="/static/django_webpack_loader_bundles/vendors.js" >'
+            '<script src="/static/django_webpack_loader_bundles/vendors.js">'
             '</script>')
         asset_app1 = (
-            '<script src="/static/django_webpack_loader_bundles/app1.js" >'
+            '<script src="/static/django_webpack_loader_bundles/app1.js">'
             '</script>')
         asset_app2 = (
-            '<script src="/static/django_webpack_loader_bundles/app2.js" >'
+            '<script src="/static/django_webpack_loader_bundles/app2.js">'
             '</script>')
 
         # Shouldn't call any `warn()` here
@@ -710,13 +710,13 @@ class LoaderTestCase(TestCase):
             ]
         }
         asset_vendor = (
-            '<script src="/static/django_webpack_loader_bundles/vendors.js" >'
+            '<script src="/static/django_webpack_loader_bundles/vendors.js">'
             '</script>')
         asset_app1 = (
-            '<script src="/static/django_webpack_loader_bundles/app1.js" >'
+            '<script src="/static/django_webpack_loader_bundles/app1.js">'
             '</script>')
         asset_app2 = (
-            '<script src="/static/django_webpack_loader_bundles/app2.js" >'
+            '<script src="/static/django_webpack_loader_bundles/app2.js">'
             '</script>')
         warning_call = MockCall(
             message=_WARNING_MESSAGE, category=RuntimeWarning)
@@ -777,7 +777,7 @@ class LoaderTestCase(TestCase):
             '{% render_bundle "app1" %}'
             '{% get_files "app2" skip_common_chunks=True as app2_files %}'
             '{% for f in app2_files %}'
-            '    <link rel="prefetch" href="{{ f.url }}" />'
+            '    <link rel="prefetch" href="{{ f.url }}"/>'
             '{% endfor %}'),
         )  # type: Template
         output = template.render(context=Context())
@@ -832,13 +832,13 @@ class LoaderTestCase(TestCase):
         """
         request = self.factory.get(path='/')
         asset_vendor = (
-            '<script src="/static/django_webpack_loader_bundles/vendors.js" >'
+            '<script src="/static/django_webpack_loader_bundles/vendors.js">'
             '</script>')
         asset_app1 = (
-            '<script src="/static/django_webpack_loader_bundles/app1.js" >'
+            '<script src="/static/django_webpack_loader_bundles/app1.js">'
             '</script>')
         asset_app2 = (
-            '<script src="/static/django_webpack_loader_bundles/app2.js" >'
+            '<script src="/static/django_webpack_loader_bundles/app2.js">'
             '</script>')
         rendered_template = template.render(
             context=None, request=request)
@@ -859,13 +859,13 @@ class LoaderTestCase(TestCase):
         """
         request = self.factory.get(path='/')
         asset_vendor = (
-            '<script src="/static/django_webpack_loader_bundles/vendors.js" >'
+            '<script src="/static/django_webpack_loader_bundles/vendors.js">'
             '</script>')
         asset_app1 = (
-            '<script src="/static/django_webpack_loader_bundles/app1.js" >'
+            '<script src="/static/django_webpack_loader_bundles/app1.js">'
             '</script>')
         asset_app2 = (
-            '<script src="/static/django_webpack_loader_bundles/app2.js" >'
+            '<script src="/static/django_webpack_loader_bundles/app2.js">'
             '</script>')
         rendered_template = template.render(
             context=None, request=request)
@@ -897,13 +897,13 @@ class LoaderTestCase(TestCase):
             ]
         }
         asset_vendor = (
-            '<script src="/static/django_webpack_loader_bundles/vendors.js" >'
+            '<script src="/static/django_webpack_loader_bundles/vendors.js">'
             '</script>')
         asset_app1 = (
-            '<script src="/static/django_webpack_loader_bundles/app1.js" >'
+            '<script src="/static/django_webpack_loader_bundles/app1.js">'
             '</script>')
         asset_app2 = (
-            '<script src="/static/django_webpack_loader_bundles/app2.js" >'
+            '<script src="/static/django_webpack_loader_bundles/app2.js">'
             '</script>')
 
         with self.settings(**settings):
@@ -940,13 +940,13 @@ class LoaderTestCase(TestCase):
             ]
         }
         asset_vendor = (
-            '<script src="/static/django_webpack_loader_bundles/vendors.js" >'
+            '<script src="/static/django_webpack_loader_bundles/vendors.js">'
             '</script>')
         asset_app1 = (
-            '<script src="/static/django_webpack_loader_bundles/app1.js" >'
+            '<script src="/static/django_webpack_loader_bundles/app1.js">'
             '</script>')
         asset_app2 = (
-            '<script src="/static/django_webpack_loader_bundles/app2.js" >'
+            '<script src="/static/django_webpack_loader_bundles/app2.js">'
             '</script>')
 
         with self.settings(**settings):
@@ -1073,9 +1073,9 @@ class LoaderTestCase(TestCase):
         template = Template(template_string=(
             '{% load render_bundle get_files from webpack_loader %}'
             '{% get_files "app1" skip_common_chunks=True as app1_files %}'
-            '{% for f in app1_files %}<link rel="prefetch" href="{{ f.url }}" />{% endfor %}'
+            '{% for f in app1_files %}<link rel="prefetch" href="{{ f.url }}"/>{% endfor %}'
             '{% get_files "app2" skip_common_chunks=True as app2_files %}'
-            '{% for f in app2_files %}<link rel="prefetch" href="{{ f.url }}" />{% endfor %}'
+            '{% for f in app2_files %}<link rel="prefetch" href="{{ f.url }}"/>{% endfor %}'
         ))
         request = self.factory.get(path='/')
         output = template.render(context=Context({'request': request}))
@@ -1091,7 +1091,7 @@ class LoaderTestCase(TestCase):
         template = Template(template_string=(
             '{% load render_bundle get_files from webpack_loader %}'
             '{% get_files "app1" skip_common_chunks=True as app1_files %}'
-            '{% for f in app1_files %}<link rel="prefetch" href="{{ f.url }}" />{% endfor %}'
+            '{% for f in app1_files %}<link rel="prefetch" href="{{ f.url }}"/>{% endfor %}'
             '{% render_bundle "app2" skip_common_chunks=True %}'
         ))
         request = self.factory.get(path='/')
@@ -1109,7 +1109,7 @@ class LoaderTestCase(TestCase):
             '{% load render_bundle get_files from webpack_loader %}'
             '{% render_bundle "app1" skip_common_chunks=True %}'
             '{% get_files "app2" skip_common_chunks=True as app2_files %}'
-            '{% for f in app2_files %}<link rel="prefetch" href="{{ f.url }}" />{% endfor %}'
+            '{% for f in app2_files %}<link rel="prefetch" href="{{ f.url }}"/>{% endfor %}'
         ))
         request = self.factory.get(path='/')
         output = template.render(context=Context({'request': request}))
@@ -1121,12 +1121,12 @@ class LoaderTestCase(TestCase):
         self.compile_bundles('webpack.config.skipCommon.js')
         
         asset_vendor = (
-            '<script src="/static/django_webpack_loader_bundles/vendors.js" >'
+            '<script src="/static/django_webpack_loader_bundles/vendors.js">'
             '</script>')
         asset_app1 = (
-            '<link href="/static/django_webpack_loader_bundles/app1.css" rel="stylesheet" />')
+            '<link href="/static/django_webpack_loader_bundles/app1.css" rel="stylesheet"/>')
         asset_app2 = (
-            '<script src="/static/django_webpack_loader_bundles/app1.js" >'
+            '<script src="/static/django_webpack_loader_bundles/app1.js">'
             '</script>')
         
         tags = get_as_tags('app1')

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -23,6 +23,7 @@ from webpack_loader.exceptions import (
     WebpackLoaderBadStatsError,
     WebpackLoaderTimeoutError,
 )
+from webpack_loader.loaders import WebpackLoader
 from webpack_loader.templatetags.webpack_loader import _WARNING_MESSAGE
 from webpack_loader.utils import get_as_tags, get_loader, get_as_url_to_tag_dict
 
@@ -419,6 +420,47 @@ class LoaderTestCase(TestCase):
             self.assertIn(
                 'Cannot resolve bundle {0}'.format(missing_bundle_name),
                 str(e))
+
+    def test_get_bundle_uses_same_assets_snapshot_when_iterated(self):
+        class ChangingAssetsLoader(WebpackLoader):
+            def __init__(self, name, config):
+                super().__init__(name, config)
+                self.load_assets_calls = 0
+                self.assets_snapshots = [
+                    {
+                        'status': 'done',
+                        'chunks': {'main': ['old.js']},
+                        'assets': {'old.js': {'name': 'old.js'}},
+                    },
+                    {
+                        'status': 'done',
+                        'chunks': {'main': ['new.js']},
+                        'assets': {'new.js': {'name': 'new.js'}},
+                    },
+                ]
+
+            def load_assets(self):
+                snapshot_index = min(
+                    self.load_assets_calls, len(self.assets_snapshots) - 1)
+                self.load_assets_calls += 1
+                return self.assets_snapshots[snapshot_index]
+
+        loader = ChangingAssetsLoader(DEFAULT_CONFIG, {
+            'CACHE': False,
+            'BUNDLE_DIR_NAME': 'django_webpack_loader_bundles/',
+            'TIMEOUT': None,
+            'POLL_INTERVAL': 0.1,
+            'ignores': [],
+            'INTEGRITY': False,
+        })
+
+        bundle = loader.get_bundle('main')
+
+        self.assertEqual(list(bundle), [{
+            'name': 'old.js',
+            'url': '/static/django_webpack_loader_bundles/old.js',
+        }])
+        self.assertEqual(loader.load_assets_calls, 1)
 
     def test_missing_stats_file(self):
         stats_file = settings.WEBPACK_LOADER[DEFAULT_CONFIG]['STATS_FILE']

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -1124,6 +1124,22 @@ class LoaderTestCase(TestCase):
             tag_dict = get_as_url_to_tag_dict('main', extension='js', attrs='', request=request_with_nonce)
             self.assertNotIn('nonce=', tag_dict['/static/django_webpack_loader_bundles/main.js'])
 
+    def test_get_url_to_tag_dict_js_preload_includes_integrity_and_nonce(self):
+        self.compile_bundles('webpack.config.integrity.js')
+
+        loader = get_loader(DEFAULT_CONFIG)
+        with patch.dict(loader.config, {'INTEGRITY': True, 'CSP_NONCE': True, 'CACHE': False}):
+            request = self.factory.get('/')
+            request.csp_nonce = 'test-nonce'
+
+            tag_dict = get_as_url_to_tag_dict('main', extension='js', attrs='', request=request, is_preload=True)
+            tag = tag_dict['http://custom-static-host.com/main.js']
+
+            self.assertIn('rel="preload"', tag)
+            self.assertIn('as="script"', tag)
+            self.assertIn('integrity=', tag)
+            self.assertIn('nonce="test-nonce"', tag)
+
     def test_get_url_to_tag_dict_with_different_extensions(self):
         """Test the get_as_url_to_tag_dict function with different file extensions."""
 

--- a/tests/app/tests/test_webpack.py
+++ b/tests/app/tests/test_webpack.py
@@ -462,6 +462,86 @@ class LoaderTestCase(TestCase):
         }])
         self.assertEqual(loader.load_assets_calls, 1)
 
+    def test_cached_compile_status_is_reloaded_while_debug_polling(self):
+        class CompilingThenDoneLoader(WebpackLoader):
+            def __init__(self, name, config):
+                super().__init__(name, config)
+                self.load_assets_calls = 0
+                self.assets_snapshots = [
+                    {'status': 'compile'},
+                    {
+                        'status': 'done',
+                        'chunks': {'main': ['main.js']},
+                        'assets': {'main.js': {'name': 'main.js'}},
+                    },
+                ]
+
+            def load_assets(self):
+                snapshot_index = min(
+                    self.load_assets_calls, len(self.assets_snapshots) - 1)
+                self.load_assets_calls += 1
+                return self.assets_snapshots[snapshot_index]
+
+        loader = CompilingThenDoneLoader('COMPILE_CACHE_DEBUG', {
+            'CACHE': True,
+            'BUNDLE_DIR_NAME': 'django_webpack_loader_bundles/',
+            'TIMEOUT': 1,
+            'POLL_INTERVAL': 0,
+            'ignores': [],
+            'INTEGRITY': False,
+        })
+
+        with self.settings(DEBUG=True):
+            bundle = loader.get_bundle('main')
+
+        self.assertEqual(list(bundle), [{
+            'name': 'main.js',
+            'url': '/static/django_webpack_loader_bundles/main.js',
+        }])
+        self.assertEqual(loader.load_assets_calls, 2)
+        self.assertEqual(loader._assets[loader.name]['status'], 'done')
+
+    def test_cached_compile_status_is_reloaded_after_bad_stats(self):
+        class CompilingThenDoneLoader(WebpackLoader):
+            def __init__(self, name, config):
+                super().__init__(name, config)
+                self.load_assets_calls = 0
+                self.assets_snapshots = [
+                    {'status': 'compile'},
+                    {
+                        'status': 'done',
+                        'chunks': {'main': ['main.js']},
+                        'assets': {'main.js': {'name': 'main.js'}},
+                    },
+                ]
+
+            def load_assets(self):
+                snapshot_index = min(
+                    self.load_assets_calls, len(self.assets_snapshots) - 1)
+                self.load_assets_calls += 1
+                return self.assets_snapshots[snapshot_index]
+
+        loader = CompilingThenDoneLoader('COMPILE_CACHE_PRODUCTION', {
+            'CACHE': True,
+            'BUNDLE_DIR_NAME': 'django_webpack_loader_bundles/',
+            'TIMEOUT': None,
+            'POLL_INTERVAL': 0.1,
+            'ignores': [],
+            'INTEGRITY': False,
+        })
+
+        with self.settings(DEBUG=False):
+            with self.assertRaises(WebpackLoaderBadStatsError):
+                loader.get_bundle('main')
+            bundle = loader.get_bundle('main')
+
+        self.assertEqual(list(bundle), [{
+            'name': 'main.js',
+            'url': '/static/django_webpack_loader_bundles/main.js',
+        }])
+        self.assertEqual(loader.load_assets_calls, 2)
+        self.assertEqual(loader._assets[loader.name]['status'], 'done')
+
     def test_missing_stats_file(self):
         stats_file = settings.WEBPACK_LOADER[DEFAULT_CONFIG]['STATS_FILE']
         if os.path.exists(stats_file):

--- a/tests_webpack5/app/tests/test_webpack.py
+++ b/tests_webpack5/app/tests/test_webpack.py
@@ -155,3 +155,19 @@ class LoaderTestCase(TestCase):
             # Test with CSP_NONCE disabled - should not have nonce
             tag_dict = get_as_url_to_tag_dict('resources', extension='js', attrs='', request=request_with_nonce)
             self.assertNotIn('nonce=', tag_dict['/static/django_webpack_loader_bundles/resources.js'])
+
+    def test_get_url_to_tag_dict_js_preload_includes_integrity_and_nonce(self):
+        self.compile_bundles('webpack.config.integrity.js')
+
+        loader = get_loader(DEFAULT_CONFIG)
+        with patch.dict(loader.config, {'INTEGRITY': True, 'CSP_NONCE': True, 'CACHE': False}):
+            request = self.factory.get('/')
+            request.csp_nonce = 'test-nonce'
+
+            tag_dict = get_as_url_to_tag_dict('resources', extension='js', attrs='', request=request, is_preload=True)
+            tag = tag_dict['http://custom-static-host.com/resources.js']
+
+            self.assertIn('rel="preload"', tag)
+            self.assertIn('as="script"', tag)
+            self.assertIn('integrity=', tag)
+            self.assertIn('nonce="test-nonce"', tag)

--- a/tests_webpack5/app/tests/test_webpack.py
+++ b/tests_webpack5/app/tests/test_webpack.py
@@ -46,7 +46,7 @@ class LoaderTestCase(TestCase):
                 'integrity="sha256-tq+bx/AOKBO9HvojLMT+nwLvdzX5q9s5hGI8sJr'
                 'V+6Q= sha384-MQ3aER73Wrl5JjMLWVotKhBZk4e9/67+xrO8/qqACm7a'
                 '695zI9sgQKa6bC54TMvb sha512-dKT17sF4HfpJC+UMIjQch07waKpAt'
-                'Tvv9GM2s/eGomGDbCKpKHGp29+6SRrQSrT2+6IF3YGu3BaoQAoAS4opOQ==" '
+                'Tvv9GM2s/eGomGDbCKpKHGp29+6SRrQSrT2+6IF3YGu3BaoQAoAS4opOQ=="'
                 '></script>'), result.rendered_content)
 
     def test_integrity_with_crossorigin_empty(self):
@@ -65,7 +65,7 @@ class LoaderTestCase(TestCase):
                 'V+6Q= sha384-MQ3aER73Wrl5JjMLWVotKhBZk4e9/67+xrO8/qqACm7a'
                 '695zI9sgQKa6bC54TMvb sha512-dKT17sF4HfpJC+UMIjQch07waKpAt'
                 'Tvv9GM2s/eGomGDbCKpKHGp29+6SRrQSrT2+6IF3YGu3BaoQAoAS4opOQ==" '
-                'crossorigin ></script>'
+                'crossorigin></script>'
             ), result.rendered_content)
 
     def test_integrity_with_crossorigin_anonymous(self):
@@ -84,7 +84,7 @@ class LoaderTestCase(TestCase):
                 'V+6Q= sha384-MQ3aER73Wrl5JjMLWVotKhBZk4e9/67+xrO8/qqACm7a'
                 '695zI9sgQKa6bC54TMvb sha512-dKT17sF4HfpJC+UMIjQch07waKpAt'
                 'Tvv9GM2s/eGomGDbCKpKHGp29+6SRrQSrT2+6IF3YGu3BaoQAoAS4opOQ==" '
-                'crossorigin="anonymous" ></script>'
+                'crossorigin="anonymous"></script>'
             ), result.rendered_content)
 
     def test_integrity_with_crossorigin_use_credentials(self):
@@ -103,7 +103,7 @@ class LoaderTestCase(TestCase):
                 'V+6Q= sha384-MQ3aER73Wrl5JjMLWVotKhBZk4e9/67+xrO8/qqACm7a'
                 '695zI9sgQKa6bC54TMvb sha512-dKT17sF4HfpJC+UMIjQch07waKpAt'
                 'Tvv9GM2s/eGomGDbCKpKHGp29+6SRrQSrT2+6IF3YGu3BaoQAoAS4opOQ==" '
-                'crossorigin="use-credentials" ></script>'
+                'crossorigin="use-credentials"></script>'
             ), result.rendered_content)
 
     def test_get_url_to_tag_dict_with_nonce(self):

--- a/webpack_loader/loaders.py
+++ b/webpack_loader/loaders.py
@@ -82,7 +82,7 @@ class WebpackLoader:
             self, request: Optional[HttpRequest], chunk: Dict[str, str],
             integrity: str, attrs_l: str) -> str:
         'Return an added `crossorigin` attribute if necessary.'
-        def_value = f' integrity="{integrity}" '
+        def_value = f'integrity="{integrity}"'
         if not request:
             message = _CROSSORIGIN_NO_REQUEST.format(chunk_name=chunk['name'])
             warn(message=message, category=RuntimeWarning)
@@ -100,15 +100,15 @@ class WebpackLoader:
             return def_value
         cfgval: str = self.config.get('CROSSORIGIN')
         if cfgval == '':
-            return f'{def_value}crossorigin '
-        return f'{def_value}crossorigin="{cfgval}" '
+            return f'{def_value} crossorigin'
+        return f'{def_value} crossorigin="{cfgval}"'
 
     def get_integrity_attr(
             self, chunk: Dict[str, str], request: Optional[HttpRequest],
-            attrs_l: str) -> str:
+            attrs_l: str) -> Optional[str]:
         if not self.config.get('INTEGRITY'):
             # Crossorigin only necessary when integrity is used
-            return ' '
+            return None
 
         integrity = chunk.get('integrity')
         if not integrity:
@@ -125,10 +125,12 @@ class WebpackLoader:
             attrs_l=attrs_l,
         )
 
-    def get_nonce_attr(self, chunk: Dict[str, str], request: Optional[HttpRequest], attrs: str) -> str:
+    def get_nonce_attr(
+            self, chunk: Dict[str, str], request: Optional[HttpRequest],
+            attrs: str) -> Optional[str]:
         'Return an added nonce for CSP when available.'
         if not self.config.get('CSP_NONCE'):
-            return ''
+            return None
         if request is None:
             message = _NONCE_NO_REQUEST.format(chunk_name=chunk['name'])
             warn(message=message, category=RuntimeWarning)
@@ -140,7 +142,7 @@ class WebpackLoader:
             return ''
         if 'nonce=' in attrs.lower():
             return ''
-        return f'nonce="{nonce}" '
+        return f'nonce="{nonce}"'
 
     def filter_chunks(self, chunks):
         filtered_chunks = []

--- a/webpack_loader/loaders.py
+++ b/webpack_loader/loaders.py
@@ -149,20 +149,21 @@ class WebpackLoader:
 
         return filtered_chunks
 
-    def map_chunk_files_to_url(self, chunks):
-        assets = self.get_assets()
+    def map_chunk_files_to_url(self, chunks, assets=None):
+        assets = assets or self.get_assets()
         files = assets["assets"]
 
         add_integrity = self.config.get("INTEGRITY")
 
         for chunk in chunks:
-            url = self.get_chunk_url(files[chunk])
+            asset = files[chunk]
+            url = self.get_chunk_url(asset)
 
             if add_integrity:
                 yield {
                     "name": chunk,
                     "url": url,
-                    "integrity": files[chunk].get("integrity"),
+                    "integrity": asset.get("integrity"),
                 }
             else:
                 yield {"name": chunk, "url": url}
@@ -219,7 +220,7 @@ class WebpackLoader:
                         "Cannot resolve asset {0}.".format(chunk)
                     )
 
-            return self.map_chunk_files_to_url(filtered_chunks)
+            return self.map_chunk_files_to_url(filtered_chunks, assets=assets)
 
         elif assets.get("status") == "error":
             if "file" not in assets:

--- a/webpack_loader/loaders.py
+++ b/webpack_loader/loaders.py
@@ -66,9 +66,12 @@ class WebpackLoader:
 
     def get_assets(self):
         if self.config["CACHE"]:
-            if self.name not in self._assets:
-                self._assets[self.name] = self.load_assets()
-            return self._assets[self.name]
+            assets = self._assets.get(self.name)
+            if not assets or assets.get("status") == "compile":
+                assets = self.load_assets()
+                if assets.get("status") != "compile":
+                    self._assets[self.name] = assets
+            return assets
         return self.load_assets()
 
     def get_asset_by_source_filename(self, name):

--- a/webpack_loader/templatetags/webpack_loader.py
+++ b/webpack_loader/templatetags/webpack_loader.py
@@ -82,8 +82,10 @@ def get_files(
         return result
 
     used_urls = getattr(request, '_webpack_loader_used_urls', None)
-    if not used_urls:
+    if used_urls is None:
         used_urls = set()
+        setattr(request, '_webpack_loader_used_urls', used_urls)
     if skip_common_chunks:
         result = [chunk for chunk in result if chunk['url'] not in used_urls]
+    used_urls.update(chunk['url'] for chunk in result)
     return result

--- a/webpack_loader/utils.py
+++ b/webpack_loader/utils.py
@@ -82,8 +82,13 @@ def get_as_url_to_tag_dict(
         if chunk['name'].endswith(('.js', '.js.gz')):
             if is_preload:
                 result[chunk['url']] = (
-                    '<link rel="preload" as="script" href="{0}" {1}/>'
-                ).format(''.join([chunk['url'], suffix]), attrs)
+                    '<link rel="preload" as="script" href="{0}"{2}{3}{1}/>'
+                ).format(
+                    ''.join([chunk['url'], suffix]),
+                    attrs,
+                    loader.get_integrity_attr(chunk, request, attrs_l),
+                    loader.get_nonce_attr(chunk, request, attrs_l),
+                )
             else:
                 result[chunk['url']] = (
                     '<script src="{0}"{2}{3}{1}></script>'

--- a/webpack_loader/utils.py
+++ b/webpack_loader/utils.py
@@ -79,34 +79,23 @@ def get_as_url_to_tag_dict(
     attrs_l = attrs.lower()
 
     for chunk in bundle:
+        url = ''.join([chunk['url'], suffix])
+        integrity = loader.get_integrity_attr(chunk, request, attrs_l)
+        nonce = loader.get_nonce_attr(chunk, request, attrs_l)
+        extra = ' '.join(filter(bool, [integrity, nonce, attrs.strip()]))
+        attrs_str = f' {extra}' if extra else ''
+
         if chunk['name'].endswith(('.js', '.js.gz')):
             if is_preload:
                 result[chunk['url']] = (
-                    '<link rel="preload" as="script" href="{0}"{2}{3}{1}/>'
-                ).format(
-                    ''.join([chunk['url'], suffix]),
-                    attrs,
-                    loader.get_integrity_attr(chunk, request, attrs_l),
-                    loader.get_nonce_attr(chunk, request, attrs_l),
+                    f'<link rel="preload" as="script" href="{url}"{attrs_str}/>'
                 )
             else:
-                result[chunk['url']] = (
-                    '<script src="{0}"{2}{3}{1}></script>'
-                ).format(
-                    ''.join([chunk['url'], suffix]),
-                    attrs,
-                    loader.get_integrity_attr(chunk, request, attrs_l),
-                    loader.get_nonce_attr(chunk, request, attrs_l),
-                )
+                result[chunk['url']] = f'<script src="{url}"{attrs_str}></script>'
         elif chunk['name'].endswith(('.css', '.css.gz')):
+            rel = '"stylesheet"' if not is_preload else '"preload" as="style"'
             result[chunk['url']] = (
-                '<link href="{0}" rel={2}{3}{4}{1}/>'
-            ).format(
-                ''.join([chunk['url'], suffix]),
-                attrs,
-                '"stylesheet"' if not is_preload else '"preload" as="style"',
-                loader.get_integrity_attr(chunk, request, attrs_l),
-                loader.get_nonce_attr(chunk, request, attrs_l),
+                f'<link href="{url}" rel={rel}{attrs_str}/>'
             )
     return result
 


### PR DESCRIPTION
Closes #426 
- Updates setup structure and changes how README.md file is parsed in there.

Closes #429 
- Fix possible race condition when re-compiling assets (hard to reproduce on development only)

Closes #430 
- Ensure we don't hit a scenario where we cache incorrect formed stats files (hard to reproduce on development only)

Closes #431  
- Brings parity between render_bundle and get_files when it uses skip_common_chunks (get_files had that property, but in the end it wasn't updating the used files in the request)
- Updates tests to ensure we don't access `TemplateView.rendered_content` multiple times per-request, as this was impacting the request used urls property

Closes #432 
- Ensure integrity and csp nonce are used for preloaded js urls (this was missing from when it was introduced as a feature last year).